### PR TITLE
Make kubeception use fibonacci retry.

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -96,6 +96,5 @@ jobs:
 
       - run: |
           echo Testing telepresence client version ${{ matrix.client_telepresence_version }} on ${{ matrix.client_os }} ${{ matrix.client_arch }} against server version ${{ matrix.cluster_telepresence_version }} on ${{ matrix.clusters.distribution }} cluster version ${{ matrix.clusters.version }}
-          cat ${KUBECONFIG}
           kubectl version
           kubectl get pods -A

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -96,5 +96,6 @@ jobs:
 
       - run: |
           echo Testing telepresence client version ${{ matrix.client_telepresence_version }} on ${{ matrix.client_os }} ${{ matrix.client_arch }} against server version ${{ matrix.cluster_telepresence_version }} on ${{ matrix.clusters.distribution }} cluster version ${{ matrix.clusters.version }}
+          cat ${KUBECONFIG}
           kubectl version
           kubectl get pods -A

--- a/provision-cluster/create.js
+++ b/provision-cluster/create.js
@@ -27,7 +27,6 @@ async function create() {
   let kubeconfig = await provider.makeKubeconfig(cluster)
   core.notice(`Cluster created: ${cluster.name}!`)
   let contents = JSON.stringify(kubeconfig, undefined, 2) + "\n"
-  core.info(`kubeconfig`, contents)
   utils.writeFile(kubeconfigPath, contents)
 
   core.notice(`Kubeconfig written to ${kubeconfigPath}.`)

--- a/provision-cluster/create.js
+++ b/provision-cluster/create.js
@@ -27,6 +27,7 @@ async function create() {
   let kubeconfig = await provider.makeKubeconfig(cluster)
   core.notice(`Cluster created: ${cluster.name}!`)
   let contents = JSON.stringify(kubeconfig, undefined, 2) + "\n"
+  core.info(`kubeconfig`, contents)
   utils.writeFile(kubeconfigPath, contents)
 
   core.notice(`Kubeconfig written to ${kubeconfigPath}.`)

--- a/provision-cluster/create.js
+++ b/provision-cluster/create.js
@@ -23,12 +23,13 @@ async function create() {
   let cluster = await provider.allocateCluster(version)
   core.saveState(registry.CLUSTER_NAME, cluster.name)
 
-  core.notice(`Created ${distribution} cluster ${cluster.name}!`)
-
+  core.notice(`Creating ${distribution} cluster ${cluster.name} ...`)
   let kubeconfig = await provider.makeKubeconfig(cluster)
+  core.notice(`Cluster created: ${cluster.name}!`)
   let contents = JSON.stringify(kubeconfig, undefined, 2) + "\n"
   utils.writeFile(kubeconfigPath, contents)
 
+  core.notice(`Kubeconfig written to ${kubeconfigPath}.`)
   core.notice(`Exporting KUBECONFIG as ${kubeconfigPath}`)
   core.exportVariable("KUBECONFIG", kubeconfigPath)
 }

--- a/provision-cluster/gke.js
+++ b/provision-cluster/gke.js
@@ -193,21 +193,15 @@ class Client {
   }
 
   // Wait for the supplied operation to finish by polling up to limit times.
-  async awaitOperation(operation, limit=20) {
-    let nextDelay = utils.fibonacciDelaySequence(1000, 30000)
-
-    for (let count = 0; count < limit; count += 1) {
+  async awaitOperation(operation) {
+    utils.fibonacciRetry(async ()=>{
       const op = await this.getOperation(operation)
       if (op.done) {
         return op
-      } else if (count < limit) {
-        let delay = nextDelay()
-        console.log(`${op.status} will try after ${delay / 1000}s delay...`)
-        await utils.sleep(delay)
       } else {
-        throw new Error(op.status)
+        throw new utils.Transient(op.status)
       }
-    }
+    })
   }
 
   // Get the current status of the supplied operation.

--- a/provision-cluster/gke.js
+++ b/provision-cluster/gke.js
@@ -194,7 +194,7 @@ class Client {
 
   // Wait for the supplied operation to finish by polling up to limit times.
   async awaitOperation(operation) {
-    utils.fibonacciRetry(async ()=>{
+    return utils.fibonacciRetry(async ()=>{
       const op = await this.getOperation(operation)
       if (op.done) {
         return op

--- a/provision-cluster/gke.js
+++ b/provision-cluster/gke.js
@@ -2,6 +2,7 @@
 
 const container = require('@google-cloud/container')
 const crypto = require('crypto')
+const utils = require('./lib/utils.js')
 
 const STATUS_ENUM = container.protos.google.container.v1.Operation.Status
 
@@ -43,7 +44,7 @@ class Client {
   // Create a new cluster with a unique name, wait for it to be fully provisioned, and then fetch
   // and return the resulting cluster object.
   async allocateCluster() {
-    let name = `test-${uid()}`
+    let name = `test-${utils.uid()}`
     let cluster = {
       name: name,
       network: 'default',
@@ -193,7 +194,7 @@ class Client {
 
   // Wait for the supplied operation to finish by polling up to limit times.
   async awaitOperation(operation, limit=20) {
-    let nextDelay = fibonacciDelaySequence(1000, 30000)
+    let nextDelay = utils.fibonacciDelaySequence(1000, 30000)
 
     for (let count = 0; count < limit; count += 1) {
       const op = await this.getOperation(operation)
@@ -202,7 +203,7 @@ class Client {
       } else if (count < limit) {
         let delay = nextDelay()
         console.log(`${op.status} will try after ${delay / 1000}s delay...`)
-        await sleep(delay)
+        await utils.sleep(delay)
       } else {
         throw new Error(op.status)
       }
@@ -246,36 +247,6 @@ class Operation {
 
 }
 
-// Convenience for sleeping in async functions/methods.
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-// Construct a thunk that returns a fibonacci sequence using the supplied initial and max delays.
-function fibonacciDelaySequence(initialDelay, maxDelay) {
-  let prevFibonacciDelay = 0
-  let curFibonacciDelay = initialDelay
-
-  return () => {
-    const result = curFibonacciDelay + prevFibonacciDelay
-    prevFibonacciDelay = curFibonacciDelay
-    curFibonacciDelay = result
-    if (typeof maxDelay === typeof undefined) {
-      return result
-    } else {
-      return Math.min(result, maxDelay)
-    }
-  }
-}
-
-// Construct a unique id.
-function uid() {
-  return crypto.randomBytes(16).toString("hex")
-}
-
 module.exports = {
-  Client,
-  sleep,
-  uid,
-  fibonacciDelaySequence
+  Client
 }

--- a/provision-cluster/gke.test.js
+++ b/provision-cluster/gke.test.js
@@ -1,43 +1,5 @@
 const gke = require('./gke.js')
 
-test('fibonacciDelaySequence unlimited', () => {
-  let seq = gke.fibonacciDelaySequence(1)
-  let prev = 0;
-  let cur = 1;
-  for (let i = 0; i < 100; i++) {
-    let next = cur + prev
-    prev = cur
-    cur = next
-    expect(seq()).toBe(cur)
-  }
-})
-
-test('fibonacciDelaySequence limited', () => {
-  let limit = 10
-  let seq = gke.fibonacciDelaySequence(1, limit)
-  let prev = 0;
-  let cur = 1;
-  for (let i = 0; i < 100; i++) {
-    let next = cur + prev
-    prev = cur
-    cur = next
-    if (cur > limit) {
-      expect(seq()).toBe(limit)
-    } else {
-      expect(seq()).toBe(cur)
-    }
-  }
-})
-
-test('uid', () => {
-  let ids = new Set()
-  for (let i = 0; i < 100; i++) {
-    let id = gke.uid()
-    expect(ids.has(id)).toBeFalsy()
-    ids.add(id)
-  }
-})
-
 const mock = require('./mock.js')
 let MOCK = mock.MOCK
 

--- a/provision-cluster/lib/kubeception.js
+++ b/provision-cluster/lib/kubeception.js
@@ -6,6 +6,7 @@ const utils = require('./utils.js')
 const yaml = require('yaml')
 
 const MAX_KLUSTER_NAME_LEN = 63
+const oneHour = 60*1000
 
 class Client {
 
@@ -63,8 +64,7 @@ async function createKluster(name, version) {
 
   const client = getHttpClient();
 
-  const oneDay = 86400
-  const response = await client.put(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}?version=${version}&wait=true&timeoutSecs=${oneDay}`);
+  const response = await client.put(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}?version=${version}&wait=true&timeoutSecs=${oneHour}`);
   if (!response || !response.message) {
     throw Error("Unknown error getting response");
   }

--- a/provision-cluster/lib/kubeception.js
+++ b/provision-cluster/lib/kubeception.js
@@ -12,7 +12,7 @@ class Client {
 
   async allocateCluster(version) {
     const clusterName = utils.getUniqueClusterName(MAX_KLUSTER_NAME_LEN)
-    const kubeConfig = createKluster(clusterName, version)
+    const kubeConfig = await createKluster(clusterName, version)
     return {
       "name": clusterName,
       "config": kubeConfig

--- a/provision-cluster/lib/kubeception.js
+++ b/provision-cluster/lib/kubeception.js
@@ -73,8 +73,11 @@ async function createKluster(name, version) {
     if (response.message.statusCode == 200) {
       return await response.readBody()
     } else if (response.message.statusCode == 425) {
+      // The kubeception API uses 425 to signal that cluster creation is "in progress", so we want
+      // to retry later.
       throw new utils.Transient(`status code ${response.message.statusCode}`)
     } else {
+      // Any other status code is likely a permanent error.
       let body = await response.readBody()
       throw new Error(`Status code ${response.message.statusCode}: ${body}`)
     }

--- a/provision-cluster/lib/kubeception.js
+++ b/provision-cluster/lib/kubeception.js
@@ -72,9 +72,12 @@ async function createKluster(name, version) {
 
     if (response.message.statusCode == 200) {
       return await response.readBody()
+    } else if (response.message.statusCode == 425) {
+      throw new utils.Transient(`status code ${response.message.statusCode}`)
+    } else {
+      let body = await response.readBody()
+      throw new Error(`Status code ${response.message.statusCode}: ${body}`)
     }
-
-    throw new utils.Transient(`status code ${response.message.statusCode}`)
   })
 }
 

--- a/provision-cluster/lib/utils.js
+++ b/provision-cluster/lib/utils.js
@@ -7,7 +7,7 @@ function getUniqueClusterName(maxNameLength) {
   const branch = process.env['GITHUB_HEAD_REF'];
   const sha = process.env['GITHUB_SHA'].substring(0, 8);
 
-  let name = `ci-${uniqueId()}-${repoName}-${sha}-${branch}`;
+  let name = `ci-${uid()}-${repoName}-${sha}-${branch}`;
   let sanitizedName = name.replace(/[^A-Za-z0-9-]/g, '-').replace(/-+$/g, '').toLowerCase().substring(0, maxNameLength);
 
 	return sanitizedName;
@@ -21,8 +21,31 @@ function writeFile(path, contents) {
   });
 }
 
-function uniqueId() {
+// Convenience for sleeping in async functions/methods.
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Construct a thunk that returns a fibonacci sequence using the supplied initial and max delays.
+function fibonacciDelaySequence(initialDelay, maxDelay) {
+  let prevFibonacciDelay = 0
+  let curFibonacciDelay = initialDelay
+
+  return () => {
+    const result = curFibonacciDelay + prevFibonacciDelay
+    prevFibonacciDelay = curFibonacciDelay
+    curFibonacciDelay = result
+    if (typeof maxDelay === typeof undefined) {
+      return result
+    } else {
+      return Math.min(result, maxDelay)
+    }
+  }
+}
+
+// Construct a unique id.
+function uid() {
   return crypto.randomBytes(16).toString("hex")
 }
 
-module.exports = { getUniqueClusterName, writeFile};
+module.exports = { getUniqueClusterName, writeFile, sleep, fibonacciDelaySequence, uid };

--- a/provision-cluster/lib/utils.js
+++ b/provision-cluster/lib/utils.js
@@ -10,7 +10,11 @@ function getUniqueClusterName(maxNameLength) {
   let name = `ci-${uid()}-${repoName}-${sha}-${branch}`;
   let sanitizedName = name.replace(/[^A-Za-z0-9-]/g, '-').replace(/-+$/g, '').toLowerCase().substring(0, maxNameLength);
 
-	return sanitizedName;
+  if (sanitizedName.endsWith("-")) {
+    sanitizedName = sanitizedName.substring(0, sanitizedName.length - 1)
+  }
+
+  return sanitizedName;
 }
 
 function writeFile(path, contents) {

--- a/provision-cluster/lib/utils.test.js
+++ b/provision-cluster/lib/utils.test.js
@@ -110,3 +110,14 @@ test('fibonacciRetry error', async () => {
   }
   expect(returned).toBeFalsy()
 })
+
+test('getUniqueClusterName', () => {
+  process.env["GITHUB_REPOSITORY"] = "repo"
+  process.env["GITHUB_HEAD_REF"] = "head-ref"
+  process.env["GITHUB_SHA"] = "1234"
+  for (let i = 10; i < 1000; i++) {
+    let name = utils.getUniqueClusterName(i)
+    expect(name.length <= i).toBeTruthy()
+    expect(name.endsWith("-")).toBeFalsy()
+  }
+})

--- a/provision-cluster/lib/utils.test.js
+++ b/provision-cluster/lib/utils.test.js
@@ -37,3 +37,76 @@ test('uid', () => {
     ids.add(id)
   }
 })
+
+test('fibonacciRetry success', async () => {
+  let count = 0
+  let result = await utils.fibonacciRetry(async ()=> {
+    count += 1
+    return count
+  })
+  expect(result).toBe(count)
+  expect(count).toBe(1)
+})
+
+test('fibonacciRetry fail some', async () => {
+  let count = 0
+  let result = await utils.fibonacciRetry(async ()=> {
+    count += 1
+    if (count > 3) {
+      return count
+    }
+    throw new utils.Transient(`${count} is not big enough`)
+  }, 100, 1)
+  expect(count).toBe(result)
+  expect(count).toBe(4)
+})
+
+test('fibonacciRetry fail all', async () => {
+  let count = 0
+  let start = Date.now()
+  let returned = false
+  try {
+    await utils.fibonacciRetry(async ()=> {
+      count += 1
+      throw new utils.Transient('never big enough')
+    }, 100, 1)
+    returned = true
+  } catch (err) {
+    let elapsed = Date.now() - start
+    expect(err.message).toContain("Transient error")
+    expect(err.message).toContain("never big enough")
+    expect(err.message).toContain("failing after")
+    expect(err.message).toContain("attempts over")
+    expect(count > 0).toBeTruthy()
+    expect(elapsed < 1000).toBeTruthy()
+  }
+
+  expect(returned).toBeFalsy()
+})
+
+test('fibonacciRetry max delay', async () => {
+  let count = 0
+  await utils.fibonacciRetry(async ()=> {
+    count += 1
+    if (count > 10) {
+      return count
+    }
+    throw new utils.Transient('never big enough')
+  }, 100, 1, 10)
+})
+
+test('fibonacciRetry error', async () => {
+  let count = 0
+  let returned = false
+  try {
+    await utils.fibonacciRetry(async ()=> {
+      count += 1
+      throw new Error('blah')
+    }, 100, 1, 10)
+    returned = true
+  } catch (err) {
+    expect(err.message).toEqual('blah')
+    expect(count).toBe(1)
+  }
+  expect(returned).toBeFalsy()
+})

--- a/provision-cluster/lib/utils.test.js
+++ b/provision-cluster/lib/utils.test.js
@@ -1,0 +1,39 @@
+const utils = require('./utils.js')
+
+test('fibonacciDelaySequence unlimited', () => {
+  let seq = utils.fibonacciDelaySequence(1)
+  let prev = 0;
+  let cur = 1;
+  for (let i = 0; i < 100; i++) {
+    let next = cur + prev
+    prev = cur
+    cur = next
+    expect(seq()).toBe(cur)
+  }
+})
+
+test('fibonacciDelaySequence limited', () => {
+  let limit = 10
+  let seq = utils.fibonacciDelaySequence(1, limit)
+  let prev = 0;
+  let cur = 1;
+  for (let i = 0; i < 100; i++) {
+    let next = cur + prev
+    prev = cur
+    cur = next
+    if (cur > limit) {
+      expect(seq()).toBe(limit)
+    } else {
+      expect(seq()).toBe(cur)
+    }
+  }
+})
+
+test('uid', () => {
+  let ids = new Set()
+  for (let i = 0; i < 100; i++) {
+    let id = utils.uid()
+    expect(ids.has(id)).toBeFalsy()
+    ids.add(id)
+  }
+})


### PR DESCRIPTION
Each commit should be simple to review in isolation:

- Switch default timeout to one hour.
- Move uid, fibonacciDelaySequence, and sleep into lib/utils.js
- Add missing await.
- Add fibonacciRetry as a convenience method.
- Wire up fibonacciRetry for kubeception.
- Use fibonacciRetry for GKE also.
