### PR TITLE
Use auth webtoken

### DIFF
--- a/github-runner-provisioner/README.md
+++ b/github-runner-provisioner/README.md
@@ -23,3 +23,10 @@ To run tests against a local instance of the provisioner use the HOSTNAME parame
 ```shell
  make test-github-provisioner HOSTNAME=http://localhost:8080
 ```
+
+# Env Vars
+The runner provisioner requires the following variables to be configured:
+- `GITHUB_TOKEN` - a personal access token with admin access to the repo configuring the runners. 
+We use the `D6E-Automaton`'s token in production.
+- `WEBHOOK_TOKEN` - the secret used to configure the webhook in GitHub. We use the token stored at 
+`/Keybase/team/datawireio/infra/github-runner-provisioner-secrets`

--- a/github-runner-provisioner/config.go
+++ b/github-runner-provisioner/config.go
@@ -1,7 +1,8 @@
 package main
 
 type Config struct {
-	GithubToken string `required:"true" envconfig:"GITHUB_TOKEN"`
+	GithubToken  string `required:"true" envconfig:"GITHUB_TOKEN"`
+	WebhookToken string `required:"true" envconfig:"WEBHOOK_TOKEN"`
 }
 
 var config *Config

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -21,24 +21,14 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//workflowJobEvent := github.WorkflowJobEvent{}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, fmt.Sprintf("Error parsing form: %v", err), http.StatusBadRequest)
+	payload, err := github.ValidatePayload(r, []byte(config.WebhookToken))
+	if err != nil {
+		http.Error(w, "Webhook token invalid", http.StatusUnauthorized)
 		return
-	}
-
-	if len(r.PostForm) == 0 {
-		http.Error(w, "Request contains no data", http.StatusBadRequest)
-		return
-	}
-
-	formData, ok := r.PostForm["payload"]
-	if !ok {
-		http.Error(w, "Request has no payload", http.StatusBadRequest)
 	}
 
 	workflowJobEvent := github.WorkflowJobEvent{}
-	err := json.Unmarshal([]byte(formData[0]), &workflowJobEvent)
+	err = json.Unmarshal(payload, &workflowJobEvent)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Request is not a workflow job event: %v", err), http.StatusBadRequest)
 		return


### PR DESCRIPTION
Uses the `go-github` `ValidatePayload` function to validate webhook calls with the webhook secret. 

Testing: Tested in another repository. I couldn't get local testing working - even with directly copied headers and payloads. 

Deployment plan: 
Update the `github-runner-provisioner-secrets` with the webhook token value & apply
Merge PR
Monitor rollout in argo
Run webhook to confirm it works