### PR TITLE
Specify an availability zone when creating Mac M1 instances

### DIFF
--- a/github-runner-provisioner/macm1.go
+++ b/github-runner-provisioner/macm1.go
@@ -55,11 +55,13 @@ type runnerConfig struct {
 }
 
 var macM1HostResourceGroupArn = "arn:aws:resource-groups:us-east-1:914373874199:group/GitHub-Runners"
+var macM1AvailabilityZone = "us-east-1a"
 
 var macM1Config = runnerConfig{
 	imageId: AMI_MACOS_12_6_ARM64,
 	placement: types.Placement{
 		HostResourceGroupArn: &macM1HostResourceGroupArn,
+		AvailabilityZone:     &macM1AvailabilityZone,
 	},
 	instanceCount:    1,
 	shutdownBehavior: "terminate",


### PR DESCRIPTION
# Description
When a Mac M1 was being ran, we didn't specify an availability zone which sometimes caused this error:
```
Error creating Mac M1 runner for job run_tests (macOS-arm64, Kubeception, 1.19) [https://github.com/telepresenceio/telepresence/actions/runs/3390344647/jobs/5634405291]: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 951170cb-293f-437f-ae33-8029f8bdeace, api error UnsupportedHostConfiguration: Your requested instance type (mac2.metal) is not supported in your requested Availability Zone (us-east-1c). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1b, us-east-1d.
```

This PR updates the instance placement to use zone us-east-1a