### PR TITLE
Expose the health check endpoint to be able to do an uptime check

### DIFF
--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -73,7 +73,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /github-runner-provisioner/healthz
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 40
@@ -83,7 +83,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /github-runner-provisioner/healthz
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 40

--- a/github-runner-provisioner/main.go
+++ b/github-runner-provisioner/main.go
@@ -18,7 +18,7 @@ func main() {
 	makeHandler := func(name string) http.Handler {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/", handleProvisioningRequest)
-		mux.HandleFunc("/healthz", handleHealthCheckRequest)
+		mux.HandleFunc("/github-runner-provisioner/healthz", handleHealthCheckRequest)
 		return mux
 	}
 


### PR DESCRIPTION
## Description

Exposed the health check on `/github-runner-provisioner/healthz` so we can monitor the provisioner using an uptime check.

## Tests

Ran app locally and checked that the old URLs are still reachable, and the health check returns a 200 code