### PR TITLE
Document GitHub webhook setup and doc clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,6 @@
-# Github Actions for Test Matrices
+# Infra-actions documentation
 
-This repository hosts github actions that can be used to provision and configure kubernetes
-clusters. These are intended to facilitate building out a comprehensive [test
-matrix](.github/workflows/matrix.yaml) suitable for use in real-world large scale integration and
-compatibility testing for both telepresence and edge-stack.
-
-The [matrix workflow](.github/workflows/matrix.yaml) illustrates an exemplary usage of these
-actions.
-
-## Cluster Provisioning
-
-The [provision-cluster](provision-cluster/README.md) action can be used to provision different
-varieties of clusters:
-
- - Kubeception (k3s based)
- - GKE
- - EKS (unimplemented)
- - AKS (unimplemented)
-
-By including this github action in your workflow you can easily run the same test suite against any
-supported set of clusters:
-
-```yaml
-...
-jobs:
-...
-  my_matrix_job:
-    strategy:
-      matrix:
-        clusters:
-         - distribution: GKE
-           version: "1.21"
-         - distribution: AKS
-           version: "1.22"
-         - distribution: Kubeception
-           version: "1.23"
-    steps:
-      # The provision-cluster action will automatically register a cleanup hook to remove the
-      # cluster it provisions when the job is done.
-      - uses: datawire/infra-actions/provision-cluster@v0.2.0
-        with:
-          distribution: ${{ matrix.clusters.distribution }}
-          version: ${{ matrix.clusters.version }}
-          # Tells provision-cluster where to write the kubeconfig file.
-          kubeconfig: kubeconfig.yaml
-
-          kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
-          gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-      - run: KUBECONFIG=kubeconifig.yaml make tests
-...
-```
+[Using the GitHub actions matrix strategy](./docs/GITHUB_ACTIONS.md)
 
 ## Cluster Setup
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,9 @@
 # Infra-actions documentation
 
-[Using the GitHub actions matrix strategy](./docs/GITHUB_ACTIONS.md)
-
-## Cluster Setup
-
-XXX: unimplemented
-
-The [setup-cluster](setup-cluster/README.md) action can be used to configure a cluster with a given
-set of manifests required for test execution. The action will not only intelligently apply the
-manifests (dealing with any interdependencies), but also ensure that all deployments, statefulsets,
-daemonsets, etc, are fully available, ready, and passing their health checks before allowing the job
-to proceed:
-
-```yaml
-...
-jobs:
-...
-  my_matrix_job:
-    ...
-    steps:
-      - uses: datawire/infra-actions/provision-cluster@v0.2.0
-        with:
-          distribution: ${{ matrix.clusters.distribution }}
-          version: ${{ matrix.clusters.version }}
-          # Tells provision-cluster where to write the kubeconfig file.
-          kubeconfig: kubeconfig.yaml
-          # For convenience, the provision-cluster manifest will invoke the setup-cluster manifest if you
-          # pass in a pointer to manifests, however you can also use it independently as shown below just
-          # in case your cluster does not come from the ./provision-cluster action.
-          #
-          # manifests: <url-or-file>
-      - uses: ./setup-cluster
-        with:
-          # Tells setup-cluster which kubeconfig file to use.
-          kubeconfig: kubeconfig.yaml
-          # The manifests parameter can point to a file or url and can include raw yaml or kustomized manifests.
-          manifests: https://github.com/datawire/my-repo/manifests.yaml
-      - run: KUBECONFIG=kubeconifig.yaml make tests
-...
-```
+- GitHub
+  - [Using the GitHub actions matrix strategy](./docs/GITHUB_ACTIONS.md)
+- Clusters
+  - [Cluster provisioning with custom manifests](./docs/CLUSTERS.md)
 
 # Custom GitHub action runners
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,9 @@
 # Infra-actions documentation
 
-- GitHub
+## GitHub
   - [Using the GitHub actions matrix strategy](./docs/GITHUB_ACTIONS.md)
-- Clusters
+  - [Self-hosted GitHub action runners](./docs/ACTION_RUNNERS.md)
+## Clusters
   - [Cluster provisioning with custom manifests](./docs/CLUSTERS.md)
-
-# Custom GitHub action runners
-
-There are Mac M1 and Ubuntu ARM64 runners available for GitHub actions.
-
-In the future, we may make additional runners available depending on the needs of the different teams.
-
-## Mac M1 runners
-
-There are self-hosted Mac M1 (ARM64) runners that can be used in a workflow by using `runs-on: macOS-arm64`.
-
-The following example shows how to use this on a matrix.
-
-```yaml
-...
-jobs:
-    my_job:
-      runs-on: macOS-arm64
-      steps:
-        # The provision-cluster action will automatically register a cleanup hook to remove the
-        # cluster it provisions when the job is done.
-        - uses: actions/checkout@v3
-        ...
-```
-
-Note that Mac M1 runners are created on demand, and it will take between 30 minutes and up to 3 hours to have one available 
-depending on how many jobs are running on them.
-
-Also, there is a limit of 10 Mac M1 runners at any point in time. Any build that requests a Mac M1 during this time will stay in a queued state and may fail.
-
-## Ubuntu ARM64 runners
-
-These self-hosted runners run on AWS and are created on-demand. It takes about a minute for the runner to be available, and once the job finishes, it's destroyed.
-
-To request one, use label `ubuntu-arm64`:
-
-```yaml
-...
-jobs:
-  my_job:
-    runs-on: ubuntu-arm64
-    steps:
-      # The provision-cluster action will automatically register a cleanup hook to remove the
-      # cluster it provisions when the job is done.
-      - uses: actions/checkout@v3
-      ...
-```
-
-# Dev loop
- See [DEVELOPING.md](docs/DEVELOPING.md)
+## Dev loop
+  - [DEVELOPING.md](docs/DEVELOPING.md)

--- a/docs/ACTION_RUNNERS.md
+++ b/docs/ACTION_RUNNERS.md
@@ -1,14 +1,27 @@
 # Custom GitHub action runners
 
-There are Mac M1 and Ubuntu ARM64 runners available for GitHub actions.
+There are self-hosted Mac M1 and Ubuntu ARM64 runners available for GitHub actions. There runners are EC2 instances 
+hosted in AWS.
 
 In the future, we may make additional runners available depending on the needs of the different teams.
+
+## Repository configuration
+
+Before a job can use a self-hosted runner, the following settings need to be configured in the GitHub repository:
+ 
+1. Add the `d6e-automaton` account as a repo administrator (`Repo -> Settings -> Collaborators and teams`)
+2. Add a webhook (`Repo -> Settings -> Webhooks`) with the following settings:
+   1. Payload URL: https://sw.bakerstreet.io/github-runner-provisioner/
+   2. Content type: application/x-www-form-urlencoded
+   3. Secret: Enter the value found in `/keybase/team/datawireio/secrets/github-actions/github-infra-actions`
+   4. SSL verification: Enable
+   5. Which events trigger the webhook? -> Let me select individual events ->  Workflow jobs
+
+Once the webhook is configured, you can use the runners as described below.
 
 ## Mac M1 runners
 
 There are self-hosted Mac M1 (ARM64) runners that can be used in a workflow by using `runs-on: macOS-arm64`.
-
-The following example shows how to use this on a matrix.
 
 ```yaml
 ...
@@ -22,14 +35,17 @@ jobs:
         ...
 ```
 
-Note that Mac M1 runners are created on demand, and it will take between 30 minutes and up to 3 hours to have one available
-depending on how many jobs are running on them.
-
-Also, there is a limit of 10 Mac M1 runners at any point in time. Any build that requests a Mac M1 during this time will stay in a queued state and may fail.
+The following limitations apply to Mac M1 runners:
+- It will take between 30 minutes and up to 3 hours for a runner to be available from the moment it's requested by a job.
+- There is a limit of 10 Mac M1 runners at any point in time. Any build that requests a Mac M1 during this time will 
+  stay in a queued state until aruner is available. If a job is queued for more than 24 hours, it will be marked as failed.
+- Once a Mac M1 runner is created, it will continue to run for up to 24 hours, picking-up oe or more jobs. What the means 
+  is that jobs are responsible for ensuring that runners are in a clean state before they are used.
 
 ## Ubuntu ARM64 runners
 
-These self-hosted runners run on AWS and are created on-demand. It takes about a minute for the runner to be available, and once the job finishes, it's destroyed.
+These self-hosted runners are created on-demand. It takes about a minute for the runner to be available, and once the 
+job finishes, they are destroyed.
 
 To request one, use label `ubuntu-arm64`:
 

--- a/docs/ACTION_RUNNERS.md
+++ b/docs/ACTION_RUNNERS.md
@@ -11,10 +11,10 @@ Before a job can use a self-hosted runner, the following settings need to be con
  
 1. Add the `d6e-automaton` account as a repo administrator (`Repo -> Settings -> Collaborators and teams`)
 2. Add a webhook (`Repo -> Settings -> Webhooks`) with the following settings:
-   1. Payload URL: https://sw.bakerstreet.io/github-runner-provisioner/
-   2. Content type: application/x-www-form-urlencoded
+   1. Payload URL: `https://sw.bakerstreet.io/github-runner-provisioner/`
+   2. Content type: `application/x-www-form-urlencoded`
    3. Secret: Enter the value found in `/keybase/team/datawireio/secrets/github-actions/github-infra-actions`
-   4. SSL verification: Enable
+   4. SSL verification: `Enable`
    5. Which events trigger the webhook? -> Let me select individual events ->  Workflow jobs
 
 Once the webhook is configured, you can use the runners as described below.

--- a/docs/ACTION_RUNNERS.md
+++ b/docs/ACTION_RUNNERS.md
@@ -38,7 +38,7 @@ jobs:
 The following limitations apply to Mac M1 runners:
 - It will take between 30 minutes and up to 3 hours for a runner to be available from the moment it's requested by a job.
 - There is a limit of 10 Mac M1 runners at any point in time. Any build that requests a Mac M1 during this time will 
-  stay in a queued state until aruner is available. If a job is queued for more than 24 hours, it will be marked as failed.
+  stay in a queued state until a runner is available. If a job is queued for more than 24 hours, it will be marked as failed.
 - Once a Mac M1 runner is created, it will continue to run for up to 24 hours, picking-up oe or more jobs. What the means 
   is that jobs are responsible for ensuring that runners are in a clean state before they are used.
 

--- a/docs/ACTION_RUNNERS.md
+++ b/docs/ACTION_RUNNERS.md
@@ -1,0 +1,46 @@
+# Custom GitHub action runners
+
+There are Mac M1 and Ubuntu ARM64 runners available for GitHub actions.
+
+In the future, we may make additional runners available depending on the needs of the different teams.
+
+## Mac M1 runners
+
+There are self-hosted Mac M1 (ARM64) runners that can be used in a workflow by using `runs-on: macOS-arm64`.
+
+The following example shows how to use this on a matrix.
+
+```yaml
+...
+jobs:
+    my_job:
+      runs-on: macOS-arm64
+      steps:
+        # The provision-cluster action will automatically register a cleanup hook to remove the
+        # cluster it provisions when the job is done.
+        - uses: actions/checkout@v3
+        ...
+```
+
+Note that Mac M1 runners are created on demand, and it will take between 30 minutes and up to 3 hours to have one available
+depending on how many jobs are running on them.
+
+Also, there is a limit of 10 Mac M1 runners at any point in time. Any build that requests a Mac M1 during this time will stay in a queued state and may fail.
+
+## Ubuntu ARM64 runners
+
+These self-hosted runners run on AWS and are created on-demand. It takes about a minute for the runner to be available, and once the job finishes, it's destroyed.
+
+To request one, use label `ubuntu-arm64`:
+
+```yaml
+...
+jobs:
+  my_job:
+    runs-on: ubuntu-arm64
+    steps:
+      # The provision-cluster action will automatically register a cleanup hook to remove the
+      # cluster it provisions when the job is done.
+      - uses: actions/checkout@v3
+      ...
+```

--- a/docs/ACTION_RUNNERS.md
+++ b/docs/ACTION_RUNNERS.md
@@ -9,13 +9,13 @@ In the future, we may make additional runners available depending on the needs o
 
 Before a job can use a self-hosted runner, the following settings need to be configured in the GitHub repository:
  
-1. Add the `d6e-automaton` account as a repo administrator (`Repo -> Settings -> Collaborators and teams`)
-2. Add a webhook (`Repo -> Settings -> Webhooks`) with the following settings:
+1. Add the `d6e-automaton` account as a repo administrator (`Repo ⇾ Settings ⇾ Collaborators and teams`)
+2. Add a webhook (`Repo ⇾ Settings ⇾ Webhooks`) with the following settings:
    1. Payload URL: `https://sw.bakerstreet.io/github-runner-provisioner/`
    2. Content type: `application/x-www-form-urlencoded`
    3. Secret: Enter the value found in `/keybase/team/datawireio/secrets/github-actions/github-infra-actions`
    4. SSL verification: `Enable`
-   5. Which events trigger the webhook? -> Let me select individual events ->  Workflow jobs
+   5. Which events trigger the webhook? `Let me select individual events` ⇾  `Workflow jobs`
 
 Once the webhook is configured, you can use the runners as described below.
 
@@ -36,8 +36,8 @@ jobs:
 ```
 
 The following limitations apply to Mac M1 runners:
-- It will take between 30 minutes and up to 3 hours for a runner to be available from the moment it's requested by a job.
-- There is a limit of 10 Mac M1 runners at any point in time. Any build that requests a Mac M1 during this time will 
+- It will take between 30 minutes and up to 3 hours for a runner to be available from the moment it is requested by a job.
+- There is a limit of 10 active Mac M1 runners. Any build that requests a Mac M1 during this time will 
   stay in a queued state until a runner is available. If a job is queued for more than 24 hours, it will be marked as failed.
 - Once a Mac M1 runner is created, it will continue to run for up to 24 hours, picking-up oe or more jobs. What the means 
   is that jobs are responsible for ensuring that runners are in a clean state before they are used.

--- a/docs/CLUSTERS.md
+++ b/docs/CLUSTERS.md
@@ -1,0 +1,37 @@
+## Cluster Setup
+
+XXX: unimplemented
+
+The [setup-cluster](setup-cluster/README.md) action can be used to configure a cluster with a given
+set of manifests required for test execution. The action will not only intelligently apply the
+manifests (dealing with any interdependencies), but also ensure that all deployments, statefulsets,
+daemonsets, etc, are fully available, ready, and passing their health checks before allowing the job
+to proceed:
+
+```yaml
+...
+jobs:
+...
+  my_matrix_job:
+    ...
+    steps:
+      - uses: datawire/infra-actions/provision-cluster@v0.2.0
+        with:
+          distribution: ${{ matrix.clusters.distribution }}
+          version: ${{ matrix.clusters.version }}
+          # Tells provision-cluster where to write the kubeconfig file.
+          kubeconfig: kubeconfig.yaml
+          # For convenience, the provision-cluster manifest will invoke the setup-cluster manifest if you
+          # pass in a pointer to manifests, however you can also use it independently as shown below just
+          # in case your cluster does not come from the ./provision-cluster action.
+          #
+          # manifests: <url-or-file>
+      - uses: ./setup-cluster
+        with:
+          # Tells setup-cluster which kubeconfig file to use.
+          kubeconfig: kubeconfig.yaml
+          # The manifests parameter can point to a file or url and can include raw yaml or kustomized manifests.
+          manifests: https://github.com/datawire/my-repo/manifests.yaml
+      - run: KUBECONFIG=kubeconifig.yaml make tests
+...
+```

--- a/docs/CLUSTERS.md
+++ b/docs/CLUSTERS.md
@@ -1,8 +1,8 @@
 ## Cluster Setup
 
-XXX: unimplemented
+Note: This section describes how this feature would work but it's not implemented.
 
-The [setup-cluster](setup-cluster/README.md) action can be used to configure a cluster with a given
+The [setup-cluster](../setup-cluster/README.md) action can be used to configure a cluster with a given
 set of manifests required for test execution. The action will not only intelligently apply the
 manifests (dealing with any interdependencies), but also ensure that all deployments, statefulsets,
 daemonsets, etc, are fully available, ready, and passing their health checks before allowing the job

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -1,0 +1,52 @@
+# Github Actions for Test Matrices
+
+This repository hosts github actions that can be used to provision and configure kubernetes
+clusters. These are intended to facilitate building out a comprehensive [test
+matrix](.github/workflows/matrix.yaml) suitable for use in real-world large scale integration and
+compatibility testing for both telepresence and edge-stack.
+
+The [matrix workflow](.github/workflows/matrix.yaml) illustrates an exemplary usage of these
+actions.
+
+## Cluster Provisioning
+
+The [provision-cluster](provision-cluster/README.md) action can be used to provision different
+varieties of clusters:
+
+- Kubeception (k3s based)
+- GKE
+- EKS (unimplemented)
+- AKS (unimplemented)
+
+By including this github action in your workflow you can easily run the same test suite against any
+supported set of clusters:
+
+```yaml
+...
+jobs:
+...
+  my_matrix_job:
+    strategy:
+      matrix:
+        clusters:
+         - distribution: GKE
+           version: "1.21"
+         - distribution: AKS
+           version: "1.22"
+         - distribution: Kubeception
+           version: "1.23"
+    steps:
+      # The provision-cluster action will automatically register a cleanup hook to remove the
+      # cluster it provisions when the job is done.
+      - uses: datawire/infra-actions/provision-cluster@v0.2.0
+        with:
+          distribution: ${{ matrix.clusters.distribution }}
+          version: ${{ matrix.clusters.version }}
+          # Tells provision-cluster where to write the kubeconfig file.
+          kubeconfig: kubeconfig.yaml
+
+          kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
+          gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      - run: KUBECONFIG=kubeconifig.yaml make tests
+...
+```

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -2,15 +2,15 @@
 
 This repository hosts github actions that can be used to provision and configure kubernetes
 clusters. These are intended to facilitate building out a comprehensive [test
-matrix](.github/workflows/matrix.yaml) suitable for use in real-world large scale integration and
+matrix](../.github/workflows/matrix.yaml) suitable for use in real-world large scale integration and
 compatibility testing for both telepresence and edge-stack.
 
-The [matrix workflow](.github/workflows/matrix.yaml) illustrates an exemplary usage of these
+The [matrix workflow](../.github/workflows/matrix.yaml) illustrates an exemplary usage of these
 actions.
 
 ## Cluster Provisioning
 
-The [provision-cluster](provision-cluster/README.md) action can be used to provision different
+The [provision-cluster](../provision-cluster/README.md) action can be used to provision different
 varieties of clusters:
 
 - Kubeception (k3s based)


### PR DESCRIPTION
This PR updates documentation as follows:
- Document how to configure the self-hosted runner Webhook on a repository
- Clean-up existing docs
- Split docs into smaller files