### PR TITLE
Increase health check delay since it takes longer to build the GitHub runner provisioner

### DIFF
--- a/.github/workflows/deploy_tests.yaml
+++ b/.github/workflows/deploy_tests.yaml
@@ -30,5 +30,5 @@ jobs:
           cd github-runner-provisioner
           kubectl create secret generic github-runner-provisioner-secrets --from-literal=AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID --from-literal=AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY --from-literal=GITHUB_TOKEN=GITHUB_TOKEN --from-literal=WEBHOOK_TOKEN=WEBHOOK_TOKEN
           kubectl apply -k . --wait
-          kubectl wait --for condition=available --timeout=2m deploy github-runner-provisioner
+          kubectl wait --for condition=available --timeout=5m deploy github-runner-provisioner
           kubectl logs -l app=github-runner-provisioner

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -77,22 +77,22 @@ spec:
           - secretRef:
               name: github-runner-provisioner-secrets
         livenessProbe:
-          failureThreshold: 3
+          failureThreshold: 5
           httpGet:
             path: /github-runner-provisioner/healthz
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 40
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         readinessProbe:
-          failureThreshold: 3
+          failureThreshold: 5
           httpGet:
             path: /github-runner-provisioner/healthz
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 40
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -96,6 +96,12 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 1000m
+          requests:
+            cpu: 100m
+            memory: 300Mi
       volumes:
         # Provide the name of the ConfigMaps containing the files you want
         # to add to the container


### PR DESCRIPTION
## Description
It's taking close to 2 minutes for the action runner provisioner to be build so the pod gets killed because the health check fails.

Increased health and ready check and set pod resources/limits which may help with a faster build.

## Blast Radius
None I can think of

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [x] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Build will test this changes

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
None

## Deployment plan
Just merge the PR