### PR TITLE
Add service monitor to GitHub action runner provisioner

### DIFF
--- a/.github/workflows/deploy_tests.yaml
+++ b/.github/workflows/deploy_tests.yaml
@@ -25,6 +25,10 @@ jobs:
           kubectl apply -f https://app.getambassador.io/yaml/edge-stack/3.3.0/aes-crds.yaml
           kubectl apply -f https://app.getambassador.io/yaml/edge-stack/3.3.0/aes.yaml
           kubectl -n ambassador wait --for condition=available --timeout=5m deploy edge-stack
+      - name: Install Prometheus Operator
+        run: |
+          set -ex
+          kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/bundle.yaml
       - name: Deploy GitHub action runner provisioner
         run: |
           set -ex

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -155,3 +155,22 @@ spec:
   selector:
     matchLabels:
       app: github-runner-provisioner
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: github-runner-provisioner
+  labels:
+    app: prometheus
+spec:
+  namespaceSelector:
+    matchNames:
+      - infra
+  selector:
+    matchLabels:
+      app: github-runner-provisioner
+  endpoints:
+    - targetPort: 8080
+      path: /metrics

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -5,6 +5,8 @@ kind: Mapping
 metadata:
   annotations: {}
   name: github-runner-provisioner
+  labels:
+    app: github-runner-provisioner
 spec:
   host: sw.bakerstreet.io
   prefix: /github-runner-provisioner/
@@ -26,6 +28,8 @@ metadata:
     a8r.io/runbook: ""
     a8r.io/uptime: ""
   name: github-runner-provisioner
+  labels:
+    app: github-runner-provisioner
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
## Description
Added ServiceMonitor that's required so Prometheus scrapes metrics

## Blast Radius
None

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [x] My changes do not require testing.

### Testing Strategy
Tested manually by adding a service monitor and checking that the metrics are scraped by Prometheus.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions


## Deployment plan
Merge PR and check that metrics are being collected