### PR TITLE
Add a pod disruption budget and update probes to handle pod evictions better

### DIFF
--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -60,7 +60,8 @@ spec:
         command: ["go", "run", "."]
         workingDir: "/src"
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
         volumeMounts:
         - name: code-root
           mountPath: "/src"
@@ -76,24 +77,28 @@ spec:
         envFrom:
           - secretRef:
               name: github-runner-provisioner-secrets
-        livenessProbe:
-          failureThreshold: 5
+        startupProbe:
           httpGet:
             path: /github-runner-provisioner/healthz
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 60
-          periodSeconds: 10
+            port: http
+          failureThreshold: 36
+          periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /github-runner-provisioner/healthz
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         readinessProbe:
-          failureThreshold: 5
+          failureThreshold: 1
           httpGet:
             path: /github-runner-provisioner/healthz
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 60
-          periodSeconds: 10
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources:

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -44,7 +44,7 @@ metadata:
   labels:
     app: github-runner-provisioner
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: github-runner-provisioner
@@ -105,7 +105,7 @@ spec:
           limits:
             cpu: 1000m
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 300Mi
       volumes:
         # Provide the name of the ConfigMaps containing the files you want

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -125,3 +125,17 @@ spec:
         - name: github-runner-provisioner-aws-config
           secret:
             secretName: github-runner-provisioner-aws-config
+
+---
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: github-runner-provisioner
+  labels:
+    app: github-runner-provisioner
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: github-runner-provisioner

--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -53,6 +53,18 @@ spec:
       labels:
         app: github-runner-provisioner
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - github-runner-provisioner
+                topologyKey: kubernetes.io/hostname
       containers:
       - name: github-runner-provisioner
         image: golang:1.18.7


### PR DESCRIPTION
## Description
Container is taking over 2 minutes to start and this is causing failures due to the health check failing.

I made the following changes to correct the issue:
1. Added a pod disruption budget so there is always one pod alive even when there is an eviction.
2. Added a startup probe that waits up to 3 minutes for the pod to be ready
3. Updated health and ready probes to fail after the first error so they are more sensitive to service failures.
4. Set deployment replicas to 2

## Blast Radius
If probes don't behave as expected it will cause downtime.

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [x] My changes do not require testing.

### Testing Strategy
- Tested in a Kluster that app starts correctly and health/ready checks work
- Tested that disruption budged will prevent all replicas from being evicted at the same time.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions


## Deployment plan
Merge PR and check that pod starts correctly