### PR TITLE
Add kubeceptionProfile input.

### DIFF
--- a/provision-cluster/action.yaml
+++ b/provision-cluster/action.yaml
@@ -34,6 +34,10 @@ inputs:
   gkeConfig:
     description: "A JSON string containing additional configuration for the given GKE cluster."
     required: false
+  kubeceptionProfile:
+    description: "The profile to use for kubeception clusters."
+    required: false
+    default: "default"
 outputs:
   clusterName:
     description: "Name of the cluster."

--- a/provision-cluster/lib/common_test.js
+++ b/provision-cluster/lib/common_test.js
@@ -1,0 +1,36 @@
+'use string';
+
+const mock = require('./mock.js')
+let MOCK = mock.MOCK
+let cluster = mock.cluster
+
+async function lifecycle(client) {
+  let allocated = await client.allocateCluster('1.22', 300)
+  let kubeconfig = await client.makeKubeconfig(allocated)
+  expect(kubeconfig).toEqual(
+    {
+      "apiVersion": "v1",
+      "kind":"Config",
+      "clusters": [{
+        "cluster": {
+          "certificate-authority-data": cluster.masterAuth.clusterCaCertificate,
+          "server":"https://34.172.65.239"
+        },
+        "name":"gke-cluster"
+      }],
+      "users": [{
+        "name":"gke-user",
+        "user":{
+          "token":MOCK.ACCESS_TOKEN
+        }}],
+      "contexts": [{
+        "context":{"cluster":"gke-cluster","namespace":"default","user":"gke-user"},
+        "name":"gke-context"}],
+      "current-context":"gke-context"
+    })
+
+  let op = await client.deleteCluster(cluster)
+  expect(op.done).toBeTruthy()
+}
+
+module.exports = { lifecycle }

--- a/provision-cluster/lib/gke.test.js
+++ b/provision-cluster/lib/gke.test.js
@@ -1,36 +1,9 @@
 'use strict';
 
 const gke = require('./gke.js')
-
+const common = require('./common_test.js')
 const mock = require('./mock.js')
-let MOCK = mock.MOCK
 
 test('gke mock e2e', async ()=> {
-  let client = mock.Client()
-  let cluster = await client.allocateCluster()
-  let kubeconfig = await client.makeKubeconfig(cluster)
-  expect(kubeconfig).toEqual(
-    {
-      "apiVersion": "v1",
-      "kind":"Config",
-      "clusters": [{
-        "cluster": {
-          "certificate-authority-data": cluster.masterAuth.clusterCaCertificate,
-          "server":"https://34.172.65.239"
-        },
-        "name":"gke-cluster"
-      }],
-      "users": [{
-        "name":"gke-user",
-        "user":{
-          "token":MOCK.ACCESS_TOKEN
-        }}],
-      "contexts": [{
-        "context":{"cluster":"gke-cluster","namespace":"default","user":"gke-user"},
-        "name":"gke-context"}],
-      "current-context":"gke-context"
-    })
-
-  let op = await client.deleteCluster(cluster)
-  expect(op.done).toBeTruthy()
+  await common.lifecycle(mock.Client())
 })

--- a/provision-cluster/lib/kubeception.js
+++ b/provision-cluster/lib/kubeception.js
@@ -59,9 +59,13 @@ class Client {
       throw Error(`kubeceptionToken is missing. Make sure that input parameter kubeceptionToken was provided`)
     }
 
+    let kubeceptionProfile = core.getInput('kubeceptionProfile')
+    if (typeof kubeceptionProfile !== typeof "" || kubeceptionProfile.trim() === "") {
+      kubeceptionProfile = "default"
+    }
 
     return utils.fibonacciRetry(async ()=>{
-      const response = await this.client.put(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}?version=${version}&timeoutSecs=${lifespan}`)
+      const response = await this.client.put(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}?version=${version}&profile=${kubeceptionProfile}&timeoutSecs=${lifespan}`)
       if (!response || !response.message) {
         throw Error("Unknown error getting response")
       }

--- a/provision-cluster/lib/kubeception.js
+++ b/provision-cluster/lib/kubeception.js
@@ -11,9 +11,13 @@ const defaultLifespan = 60*60 // One hour worth of seconds
 
 class Client {
 
+  constructor(client) {
+    this.client = client
+  }
+
   async allocateCluster(version, lifespan) {
     const clusterName = utils.getUniqueClusterName(MAX_KLUSTER_NAME_LEN)
-    const kubeConfig = await createKluster(clusterName, version, lifespan)
+    const kubeConfig = await this.createKluster(clusterName, version, lifespan)
     return {
       "name": clusterName,
       "config": kubeConfig
@@ -29,12 +33,71 @@ class Client {
   }
 
   async deleteCluster(clusterName) {
-    return deleteKluster(clusterName)
+    return this.deleteKluster(clusterName)
   }
 
   async expireClusters() {
     // Kubeception automatically expires klusters, no client side expiration is required.
     return []
+  }
+
+  async createKluster(name, version, lifespan) {
+    if (!name) {
+      throw new Error('Function createKluster() needs a Kluster name')
+    }
+
+    if (!version) {
+      throw Error('Function createKluster() needs a Kluster version')
+    }
+
+    if (typeof lifespan === typeof undefined || lifespan === "" || lifespan === 0) {
+      lifespan = defaultLifespan
+    }
+
+    const kubeceptionToken = core.getInput('kubeceptionToken')
+    if (!kubeceptionToken) {
+      throw Error(`kubeceptionToken is missing. Make sure that input parameter kubeceptionToken was provided`)
+    }
+
+
+    return utils.fibonacciRetry(async ()=>{
+      const response = await this.client.put(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}?version=${version}&timeoutSecs=${lifespan}`)
+      if (!response || !response.message) {
+        throw Error("Unknown error getting response")
+      }
+
+      if (response.message.statusCode == 200) {
+        return await response.readBody()
+      } else if (response.message.statusCode == 425) {
+        // The kubeception API uses 425 to signal that cluster creation is "in progress", so we want
+        // to retry later.
+        throw new utils.Transient(`status code ${response.message.statusCode}`)
+      } else {
+        // Any other status code is likely a permanent error.
+        let body = await response.readBody()
+        throw new Error(`Status code ${response.message.statusCode}: ${body}`)
+      }
+    })
+  }
+
+  async deleteKluster(name) {
+    if (!name) {
+      throw Error('Function deleteKluster() needs a Kluster name')
+    }
+
+    const response = await this.client.del(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}`)
+    if (!response || !response.message) {
+      throw Error("Unknown error getting response")
+    }
+
+    if (response.message.statusCode == 200) {
+      return {
+        done: true,
+        status: "deleted"
+      }
+    } else {
+      throw Error(`Expected status code 200 but got ${response.message.statusCode}`)
+    }
   }
 }
 
@@ -50,61 +113,4 @@ function getHttpClient() {
   return new httpClient.HttpClient(userAgent, [credentialHandler])
 }
 
-async function createKluster(name, version, lifespan) {
-  if (!name) {
-    throw new Error('Function createKluster() needs a Kluster name')
-  }
-
-  if (!version) {
-    throw Error('Function createKluster() needs a Kluster version')
-  }
-
-  if (typeof lifespan === typeof undefined || lifespan === "" || lifespan === 0) {
-    lifespan = defaultLifespan
-  }
-
-  const kubeceptionToken = core.getInput('kubeceptionToken')
-  if (!kubeceptionToken) {
-    throw Error(`kubeceptionToken is missing. Make sure that input parameter kubeceptionToken was provided`)
-  }
-
-  const client = getHttpClient()
-
-  return utils.fibonacciRetry(async ()=>{
-    const response = await client.put(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}?version=${version}&timeoutSecs=${lifespan}`)
-    if (!response || !response.message) {
-      throw Error("Unknown error getting response")
-    }
-
-    if (response.message.statusCode == 200) {
-      return await response.readBody()
-    } else if (response.message.statusCode == 425) {
-      // The kubeception API uses 425 to signal that cluster creation is "in progress", so we want
-      // to retry later.
-      throw new utils.Transient(`status code ${response.message.statusCode}`)
-    } else {
-      // Any other status code is likely a permanent error.
-      let body = await response.readBody()
-      throw new Error(`Status code ${response.message.statusCode}: ${body}`)
-    }
-  })
-}
-
-async function deleteKluster(name) {
-  if (!name) {
-    throw Error('Function deleteKluster() needs a Kluster name')
-  }
-
-  const client = getHttpClient()
-
-  const response = await client.del(`https://sw.bakerstreet.io/kubeception/api/klusters/${name}`)
-  if (!response || !response.message) {
-    throw Error("Unknown error getting response")
-  }
-
-  if (response.message.statusCode != 200) {
-    throw Error(`Expected status code 200 but got ${response.message.statusCode}`)
-  }
-}
-
-module.exports = { Client, createKluster, deleteKluster}
+module.exports = { Client, getHttpClient }

--- a/provision-cluster/lib/kubeception.test.js
+++ b/provision-cluster/lib/kubeception.test.js
@@ -10,13 +10,17 @@ const URL = require('node:url').URL
 
 test('kubeception profile', async ()=>{
   let inputs = {
-    kubeceptionToken: 'mock-kube-token'
+    kubeceptionToken: 'mock-kube-token',
+    kubeceptionProfile: 'mock-profile'
   }
 
   let count = 0;
 
   class MockHttpClient {
     async put(url) {
+      let parsed = new URL(url)
+      expect(parsed.searchParams.get('profile')).toBe(inputs.kubeceptionProfile)
+
       let status = 200
       if (count < 2) {
         status = 425

--- a/provision-cluster/lib/kubeception.test.js
+++ b/provision-cluster/lib/kubeception.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const core = require('@actions/core')
+const kubeception = require('./kubeception.js')
+const common = require('./common_test.js')
+const mock = require('./mock.js')
+const MOCK = mock.MOCK
+const cluster = mock.cluster
+const URL = require('node:url').URL
+
+test('kubeception profile', async ()=>{
+  let inputs = {
+    kubeceptionToken: 'mock-kube-token'
+  }
+
+  let count = 0;
+
+  class MockHttpClient {
+    async put(url) {
+      let status = 200
+      if (count < 2) {
+        status = 425
+        count = count + 1
+      } else {
+        status = 200
+      }
+      return {
+        message: {
+          statusCode: status,
+        },
+        readBody: ()=>{
+          return JSON.stringify({
+            "apiVersion": "v1",
+            "kind":"Config",
+            "clusters": [{
+              "cluster": {
+                "certificate-authority-data": cluster.masterAuth.clusterCaCertificate,
+                "server":"https://34.172.65.239"
+              },
+              "name":"gke-cluster"
+            }],
+            "users": [{
+              "name":"gke-user",
+              "user":{
+                "token":MOCK.ACCESS_TOKEN
+              }}],
+            "contexts": [{
+              "context":{"cluster":"gke-cluster","namespace":"default","user":"gke-user"},
+              "name":"gke-context"}],
+            "current-context":"gke-context"
+          })
+        }
+      }
+    }
+    async del(url) {
+      return {
+        message: {
+          statusCode: 200
+        }
+      }
+    }
+  }
+
+  process.env.GITHUB_REPOSITORY = 'test-project-repo'
+  process.env.GITHUB_HEAD_REF = 'refs/pull/1234'
+  process.env.GITHUB_SHA = 'abc1234'
+  core.getInput = (name)=>{
+    return inputs[name]
+  }
+  await common.lifecycle(new kubeception.Client(new MockHttpClient()))
+})

--- a/provision-cluster/lib/kubeception.test.js
+++ b/provision-cluster/lib/kubeception.test.js
@@ -6,7 +6,7 @@ const common = require('./common_test.js')
 const mock = require('./mock.js')
 const MOCK = mock.MOCK
 const cluster = mock.cluster
-const URL = require('node:url').URL
+const URL = require('url').URL
 
 test('kubeception profile', async ()=>{
   let inputs = {

--- a/provision-cluster/lib/mock.js
+++ b/provision-cluster/lib/mock.js
@@ -69,5 +69,6 @@ function Client() {
 module.exports = {
   MOCK,
   Client,
-  MockGKE
+  MockGKE,
+  cluster
 }

--- a/provision-cluster/lib/registry.js
+++ b/provision-cluster/lib/registry.js
@@ -8,7 +8,7 @@ const clusterZone = 'us-central1-b'
 
 const distributions = {
   "gke": new gke.Client(clusterZone),
-  "kubeception": new kubeception.Client()
+  "kubeception": new kubeception.Client(getHttpClient())
 }
 
 function getProvider(distribution) {

--- a/provision-cluster/lib/registry.js
+++ b/provision-cluster/lib/registry.js
@@ -8,7 +8,7 @@ const clusterZone = 'us-central1-b'
 
 const distributions = {
   "gke": new gke.Client(clusterZone),
-  "kubeception": new kubeception.Client(getHttpClient())
+  "kubeception": new kubeception.Client(kubeception.getHttpClient())
 }
 
 function getProvider(distribution) {


### PR DESCRIPTION

## Description

Add support for the kubeceptionProfile token. The first commit is mostly a minor refactor to allow
testing of the kubeception SPI with a mock http client. Each commit can be reviewed independently
for easier consumption:

- Make kubeception implementation mockable and turn gke test into a shared lifecycle test.
- Add a kubeceptionProfile parameter along with a test.

## Blast Radius

Small: if this is broken it would break any github workflows that use this action, however since
they are pinned, this would only happen when users voluntarily upgrade.

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [ ] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [x] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy

My testing strategy is to use a mock http client that can then assert that the correct parameters
are being passed to kubeception. This permits fast local unit tests and is robust so long as the
kubeception API remains stable/backwards compatible.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions

This is necessary because the integration environment will benefit from larger klusters, so it's
good to be able to request them.

## Deployment plan

This will be smoke tested and then released.
