### PR TITLE
Fix cluster-provisioning action

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -33,7 +33,7 @@ jobs:
       # cluster it provisions when the job is done.
       # todo: update once changes are merged
       - id: provision
-        uses: datawire/infra-actions/provision-cluster@v0.2.4
+        uses: datawire/infra-actions/provision-cluster@v0.2.5
         with:
           distribution: ${{ matrix.clusters.distribution }}
           version: ${{ matrix.clusters.version }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -25,7 +25,6 @@ jobs:
            version: "1.22"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Kubectl tool installer
         uses: Azure/setup-kubectl@v3
         with:

--- a/provision-cluster/action.yaml
+++ b/provision-cluster/action.yaml
@@ -55,8 +55,16 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Checkout action code
+      uses: actions/checkout@v3
+      env:
+        REPO: ${{ github.action_repository }}
+        REF: ${{ github.action_ref }}
+      with:
+        repository: ${{ env.REPO }}
+        ref: ${{ env.REF }}
     - id: provision-cluster
-      uses: ./.github/actions/provision-cluster # TODO: Replace reference
+      uses: ./.github/actions/provision-cluster
       with:
         distribution: ${{ inputs.distribution }}
         action: ${{ inputs.action }}


### PR DESCRIPTION
## Description
The `provision-cluster` action was not working when referenced using the syntax `datawire/infra-actions/provision-cluster@VERSION` since the action could not find all the files required to run.

To fix this, the first thing action does is to check out the source of the version being used.

## Blast Radius
None. Repos used pinned versions.

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [x] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Tested by referencing the action from the Telepresence Pro [repo](https://github.com/datawire/telepresence-pro/actions/runs/3833478103).

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
N/A

## Deployment plan
N/A