### PR TITLE
Tell ArgoCD to ignore configmaps that are generated by kustomiz from the diff.

### DIFF
--- a/github-runner-provisioner/kustomization.yaml
+++ b/github-runner-provisioner/kustomization.yaml
@@ -1,6 +1,10 @@
 resources:
 - github-runner-provisioner.yaml
 
+generatorOptions:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+
 configMapGenerator:
   - name: code-root
     files:


### PR DESCRIPTION
## Description
This will tel ArgoCD to exclude configmaps generated by kustomize from the syns status.
This will make the application appear as in-sync when a new version of the app is deployed.

## Blast Radius
None I can think of

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

I'll test it once chane is deployed.

### Testing Strategy
Make sure that new versions of the configmaps do not make the app show as out of sync.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions

## Deployment plan
- [ ] Merge PR
- [ ] Test that sync shows correctly.