### PR TITLE
Expose a Prometheus metric for GitHub runner provisioning errors

### DIFF
--- a/github-runner-provisioner/go.mod
+++ b/github-runner-provisioner/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v48 v48.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/prometheus/client_golang v1.13.1
+	github.com/prometheus/client_golang v1.14.0
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/exp v0.0.0-20221026153819-32f3d567a233
 	golang.org/x/oauth2 v0.1.0
@@ -34,7 +34,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect

--- a/github-runner-provisioner/go.sum
+++ b/github-runner-provisioner/go.sum
@@ -206,11 +206,15 @@ github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqr
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.13.1 h1:3gMjIY2+/hzmqhtUC/aQNYldJA6DtH3CgQvwS+02K1c=
 github.com/prometheus/client_golang v1.13.1/go.mod h1:vTeo+zgvILHsnnj/39Ou/1fPN5nJFOEMgftOUOmlvYQ=
+github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
+github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
+github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=

--- a/github-runner-provisioner/internal/monitoring/prometheus.go
+++ b/github-runner-provisioner/internal/monitoring/prometheus.go
@@ -39,7 +39,7 @@ var ActionRunnerRuntime = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name:      "runtime",
 	Help:      "How long has an action runner been up."}, []string{"label", "instance_id"})
 
-var RunnerErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+var RunnerProvisioningErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "action_runner",
-	Name:      "errors",
+	Name:      "provisioning_errors",
 	Help:      "Errors managing runners on AWS."}, []string{"error", "runner_label"})

--- a/github-runner-provisioner/internal/monitoring/prometheus.go
+++ b/github-runner-provisioner/internal/monitoring/prometheus.go
@@ -5,6 +5,35 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+type ProvisioningError int
+
+const (
+	ErrorBadRequest ProvisioningError = iota
+	ErrorInvalidAuthentication
+	ErrorInvalidPayload
+	ErrorUnknownAction
+	ErrorUnknownRunnerLabel
+	ErrorRunnerCreation
+)
+
+func (s ProvisioningError) String() string {
+	switch s {
+	case ErrorBadRequest:
+		return "bad_request"
+	case ErrorInvalidAuthentication:
+		return "authentication_error"
+	case ErrorInvalidPayload:
+		return "invalid_request"
+	case ErrorUnknownAction:
+		return "unknown_workflow_action"
+	case ErrorUnknownRunnerLabel:
+		return "unknown_runner_label"
+	case ErrorRunnerCreation:
+		return "runner_creation_error"
+	}
+	return "unknown_error"
+}
+
 var ActionRunnerRuntime = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Subsystem: "action_runner",
 	Name:      "runtime",

--- a/github-runner-provisioner/internal/monitoring/prometheus.go
+++ b/github-runner-provisioner/internal/monitoring/prometheus.go
@@ -9,3 +9,8 @@ var ActionRunnerRuntime = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Subsystem: "action_runner",
 	Name:      "runtime",
 	Help:      "How long has an action runner been up."}, []string{"label", "instance_id"})
+
+var RunnerErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+	Subsystem: "action_runner",
+	Name:      "errors",
+	Help:      "Errors managing runners on AWS."}, []string{"error", "runner_label"})

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -15,20 +15,20 @@ import (
 func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	if !strings.HasPrefix(r.URL.String(), "/github-runner-provisioner") {
 		http.Error(w, fmt.Sprintf("URL %s is invalid", r.URL.String()), http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "BadRequest"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
 		return
 	}
 
 	if r.Method != http.MethodPost {
 		http.Error(w, "Only the POST method supported", http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "BadRequest"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
 		return
 	}
 
 	payload, err := github.ValidatePayload(r, []byte(cfg.WebhookToken))
 	if err != nil {
 		http.Error(w, "Webhook token invalid", http.StatusUnauthorized)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "InvalidToken"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String()}).Inc()
 		return
 	}
 
@@ -36,19 +36,19 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(payload, &workflowJobEvent)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Request is not a workflow job event: %v", err), http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "InvalidRequestPayload"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String()}).Inc()
 		return
 	}
 
 	if workflowJobEvent.Action == nil {
 		http.Error(w, "Workflow action is unknown", http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "UnknownAction"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
 		return
 	}
 
 	if *workflowJobEvent.Action != "queued" {
 		log.Printf("Ignoring GitHub event with action %s.", *workflowJobEvent.Action)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "UnknownAction"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
 		http.Error(w, "OK", http.StatusOK)
 		return
 	}
@@ -66,7 +66,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 
 	if runnerFunction == nil {
 		http.Error(w, fmt.Sprintf("Workflow job didn't request a supported runner. Requested %v", workflowJobEvent.WorkflowJob.Labels), http.StatusOK)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "UnknownLabel"}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String()}).Inc()
 		return
 	}
 
@@ -84,7 +84,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	if err := runnerFunction(r.Context(), *workflowJobEvent.Repo.Owner.Login, *workflowJobEvent.Repo.Name, dryRun); err != nil {
 		log.Printf("Error creating %s runner for job %s [%s]: %v", jobLabel, *workflowJobEvent.WorkflowJob.Name, *workflowJobEvent.WorkflowJob.HTMLURL, err)
 		http.Error(w, fmt.Sprintf("Error creating %s runner: %v", jobLabel, err), http.StatusInternalServerError)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": "RunnerCreation", "runner_label": jobLabel}).Inc()
+		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorRunnerCreation.String(), "runner_label": jobLabel}).Inc()
 		return
 	}
 

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -18,7 +18,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String(), "runner_label": ""}).Inc()
 		return
 	}
 
@@ -27,7 +27,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String(), "runner_label": ""}).Inc()
 		return
 	}
 
@@ -37,7 +37,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusUnauthorized)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String(), "runner_label": ""}).Inc()
 		return
 	}
 
@@ -48,7 +48,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String(), "runner_label": ""}).Inc()
 		return
 	}
 
@@ -57,7 +57,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(), "runner_label": ""}).Inc()
 		return
 	}
 
@@ -65,7 +65,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Ignoring GitHub event with action %s for repository %s", *workflowJobEvent.Action, *workflowJobEvent.Repo.Name)
 		http.Error(w, "OK", http.StatusOK)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(), "runner_label": ""}).Inc()
 		return
 	}
 
@@ -85,7 +85,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusOK)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(), "runner_label": ""}).Inc()
 		return
 	}
 

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -15,20 +15,20 @@ import (
 func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	if !strings.HasPrefix(r.URL.String(), "/github-runner-provisioner") {
 		http.Error(w, fmt.Sprintf("URL %s is invalid", r.URL.String()), http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
 		return
 	}
 
 	if r.Method != http.MethodPost {
 		http.Error(w, "Only the POST method supported", http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String()}).Inc()
 		return
 	}
 
 	payload, err := github.ValidatePayload(r, []byte(cfg.WebhookToken))
 	if err != nil {
 		http.Error(w, "Webhook token invalid", http.StatusUnauthorized)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String()}).Inc()
 		return
 	}
 
@@ -36,19 +36,19 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(payload, &workflowJobEvent)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Request is not a workflow job event: %v", err), http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String()}).Inc()
 		return
 	}
 
 	if workflowJobEvent.Action == nil {
 		http.Error(w, "Workflow action is unknown", http.StatusBadRequest)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
 		return
 	}
 
 	if *workflowJobEvent.Action != "queued" {
 		log.Printf("Ignoring GitHub event with action %s.", *workflowJobEvent.Action)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String()}).Inc()
 		http.Error(w, "OK", http.StatusOK)
 		return
 	}
@@ -66,7 +66,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 
 	if runnerFunction == nil {
 		http.Error(w, fmt.Sprintf("Workflow job didn't request a supported runner. Requested %v", workflowJobEvent.WorkflowJob.Labels), http.StatusOK)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String()}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String()}).Inc()
 		return
 	}
 
@@ -84,7 +84,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	if err := runnerFunction(r.Context(), *workflowJobEvent.Repo.Owner.Login, *workflowJobEvent.Repo.Name, dryRun); err != nil {
 		log.Printf("Error creating %s runner for job %s [%s]: %v", jobLabel, *workflowJobEvent.WorkflowJob.Name, *workflowJobEvent.WorkflowJob.HTMLURL, err)
 		http.Error(w, fmt.Sprintf("Error creating %s runner: %v", jobLabel, err), http.StatusInternalServerError)
-		monitoring.RunnerErrors.With(prometheus.Labels{"error": monitoring.ErrorRunnerCreation.String(), "runner_label": jobLabel}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorRunnerCreation.String(), "runner_label": jobLabel}).Inc()
 		return
 	}
 


### PR DESCRIPTION
## Description
This change adds a counter that will track different errors that can happen when the action runner provisioner finds an error while processing a request from GitHub.

In addition, I improved logging for errors during provisioning

## Blast Radius
None.

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [x] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [ ] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

Note: There is a different corrective action for creating a checklist for this app.

## Testing
- [x] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Manual tests to verify that the counter increases when there is an error.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
[Add an alert for when the GitHub runner provisioner can’t create runners.](https://www.notion.so/datawire/Add-an-alert-for-when-the-GitHub-runner-provisioner-can-t-create-runners-90a2312f5aee4a52a38554bb25d7e416)

## Deployment plan
Merge PR