### PR TITLE
Improve check for available runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test-ubuntu-arm64:
 .PHONY: test-macOS-arm64
 test-macOS-arm64:
 	# SHA can be calculated like this:
-	#echo -n "payload=$(cat github-runner-provisioner/test/macos-arm64_payload.json)" | openssl dgst -sha1 -hmac FAKE_TOKEN
+	#echo -n "payload=$(cat github-runner-provisioner/test/macOS-arm64_payload.json)" | openssl dgst -sha1 -hmac FAKE_TOKEN
 
 	make test-github-provisioner SHA1=e504cfa93721fbea2a394d4de9c9be7d5270fc19 RUNNER_TAG=macOS-arm64
 

--- a/github-runner-provisioner/github.go
+++ b/github-runner-provisioner/github.go
@@ -38,10 +38,10 @@ func getGitHubRunners(ctx context.Context, owner string, repo string) (*github.R
 	return runners, nil
 }
 
-func isRunnerAvailable(ctx context.Context, owner string, repo string, labels []string) bool {
+func isRunnerAvailable(ctx context.Context, owner string, repo string, labels []string) (bool, error) {
 	runners, err := getGitHubRunners(ctx, owner, repo)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	//check all runners registered to the repo
@@ -58,11 +58,11 @@ func isRunnerAvailable(ctx context.Context, owner string, repo string, labels []
 		}
 
 		if labelsMatch(labels, runnerLabelNames) {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func labelsMatch(labels []string, runnerLabelNames []string) bool {

--- a/github-runner-provisioner/internal/monitoring/prometheus.go
+++ b/github-runner-provisioner/internal/monitoring/prometheus.go
@@ -14,6 +14,7 @@ const (
 	ErrorUnknownAction
 	ErrorUnknownRunnerLabel
 	ErrorRunnerCreation
+	ErrorCheckingAvailableRunners
 )
 
 func (s ProvisioningError) String() string {
@@ -30,6 +31,8 @@ func (s ProvisioningError) String() string {
 		return "unknown_runner_label"
 	case ErrorRunnerCreation:
 		return "runner_creation_error"
+	case ErrorCheckingAvailableRunners:
+		return "availability_check_error"
 	}
 	return "unknown_error"
 }

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -85,7 +85,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusOK)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(), "runner_label": jobLabel}).Inc()
 		return
 	}
 

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -63,7 +63,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 
 	if *workflowJobEvent.Action != "queued" {
 		log.Printf("Ignoring GitHub event with action %s for repository %s", *workflowJobEvent.Action, *workflowJobEvent.Repo.Name)
-		http.Error(w, "OK", http.StatusOK)
+		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
 
 		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(), "runner_label": ""}).Inc()
 		return
@@ -104,10 +104,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 
 	if isAvailable {
 		log.Printf("%s runner already available. No scaling action required.", jobLabel)
-		if _, err := w.Write([]byte("OK")); err != nil {
-			log.Printf("Error sending HTTP response: %v", err)
-		}
-
+		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
 		return
 	}
 
@@ -122,9 +119,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("%s runner has been scheduled for job %s\n", jobLabel, *workflowJobEvent.Repo.Name)
-	if _, err := w.Write([]byte("OK")); err != nil {
-		log.Printf("Error sending HTTP response: %v", err)
-	}
+	http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
 }
 
 func handleHealthCheckRequest(w http.ResponseWriter, _ *http.Request) {

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -107,6 +107,8 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		if _, err := w.Write([]byte("OK")); err != nil {
 			log.Printf("Error sending HTTP response: %v", err)
 		}
+
+		return
 	}
 
 	dryRun := len(r.Form["dry-run"]) > 0 && r.Form["dry-run"][0] == "true"

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -103,7 +103,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if isAvailable {
-		log.Printf("%s runner already available. No action scaling action required.", jobLabel)
+		log.Printf("%s runner already available. No scaling action required.", jobLabel)
 		if _, err := w.Write([]byte("OK")); err != nil {
 			log.Printf("Error sending HTTP response: %v", err)
 		}


### PR DESCRIPTION
## Description
The function that checks if a GitHub runner is available was swallowing errors, which made it harder to troubleshoot issues.
Also, when a runner was already available, the provisioner ignored this and created a new one.

I also fixed the following issues:
- Instructions for generating an SHA used in tests, which made testing this harder.
- Added missing labels in a Prometheus counter

## Blast Radius
It could break provisioning of new runners

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [ ] My changes do not have any impact on Rosie's checklists.

## Testing
- [x] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Run the app locally and checked that a runner can be provisioned

## Security
- [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
List any issues or corrective actions related to this PR.

## Deployment plan
Describe what steps are necessary after merging PR, like:
- Manual tests.
- Dashboards or other monitoring tools that will be used to identify possible issues.