### PR TITLE
Send an alert when the provisioner has issues creating a GitHub runner

### DIFF
--- a/github-runner-provisioner/github-runner-provisioner.yaml
+++ b/github-runner-provisioner/github-runner-provisioner.yaml
@@ -174,3 +174,23 @@ spec:
   endpoints:
     - targetPort: 8080
       path: /metrics
+
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: github-runner-provisioner
+  labels:
+    app: prometheus
+spec:
+  groups:
+    - name: github-runner-provisioner
+      rules:
+        - alert: GitHub runner provisioner error
+          expr: sum(rate(action_runner_provisioning_errors{error=~"availability_check_error|runner_creation_error"}[1m])) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: There was an error provisioning a GitHub runner.
+            link: https://www.notion.so/datawire/Runbook-Infra-Actions-4ce5640bde494304a039779727be2c0d

--- a/github-runner-provisioner/internal/monitoring/prometheus.go
+++ b/github-runner-provisioner/internal/monitoring/prometheus.go
@@ -45,14 +45,14 @@ var ActionRunnerRuntime = promauto.NewGaugeVec(prometheus.GaugeOpts{
 var RunnerProvisioningErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "action_runner",
 	Name:      "provisioning_errors",
-	Help:      "Errors managing runners on AWS."}, []string{"error", "runner_label"})
+	Help:      "Errors managing runners on AWS."}, []string{"error", "runner_label", "repo"})
 
 func init() {
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorBadRequest.String(), "runner_label": ""})
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorInvalidAuthentication.String(), "runner_label": ""})
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorInvalidPayload.String(), "runner_label": ""})
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorUnknownAction.String(), "runner_label": ""})
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorUnknownRunnerLabel.String(), "runner_label": ""})
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorRunnerCreation.String(), "runner_label": ""})
-	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorCheckingAvailableRunners.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorBadRequest.String(), "runner_label": "", "repo": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorInvalidAuthentication.String(), "runner_label": "", "repo": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorInvalidPayload.String(), "runner_label": "", "repo": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorUnknownAction.String(), "runner_label": "", "repo": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorUnknownRunnerLabel.String(), "runner_label": "", "repo": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorRunnerCreation.String(), "runner_label": "", "repo": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorCheckingAvailableRunners.String(), "runner_label": "", "repo": ""})
 }

--- a/github-runner-provisioner/internal/monitoring/prometheus.go
+++ b/github-runner-provisioner/internal/monitoring/prometheus.go
@@ -46,3 +46,13 @@ var RunnerProvisioningErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "action_runner",
 	Name:      "provisioning_errors",
 	Help:      "Errors managing runners on AWS."}, []string{"error", "runner_label"})
+
+func init() {
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorBadRequest.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorInvalidAuthentication.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorInvalidPayload.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorUnknownAction.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorUnknownRunnerLabel.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorRunnerCreation.String(), "runner_label": ""})
+	RunnerProvisioningErrors.With(prometheus.Labels{"error": ErrorCheckingAvailableRunners.String(), "runner_label": ""})
+}

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -18,7 +18,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String(), "runner_label": "", "repo": ""}).Inc()
 		return
 	}
 
@@ -27,7 +27,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorBadRequest.String(), "runner_label": "", "repo": ""}).Inc()
 		return
 	}
 
@@ -37,7 +37,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusUnauthorized)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidAuthentication.String(), "runner_label": "", "repo": ""}).Inc()
 		return
 	}
 
@@ -48,7 +48,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String(), "runner_label": "", "repo": ""}).Inc()
 		return
 	}
 
@@ -57,7 +57,8 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(),
+			"runner_label": "", "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
 
@@ -65,7 +66,8 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Ignoring GitHub event with action %s for repository %s", *workflowJobEvent.Action, *workflowJobEvent.Repo.Name)
 		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(), "runner_label": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(),
+			"runner_label": "", "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
 
@@ -85,7 +87,8 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusOK)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(), "runner_label": jobLabel}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(),
+			"runner_label": jobLabel, "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
 
@@ -98,7 +101,8 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusInternalServerError)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorCheckingAvailableRunners.String(), "runner_label": jobLabel}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorCheckingAvailableRunners.String(),
+			"runner_label": jobLabel, "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
 
@@ -114,7 +118,8 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusInternalServerError)
 		log.Printf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorRunnerCreation.String(), "runner_label": jobLabel}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorRunnerCreation.String(),
+			"runner_label": jobLabel, "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
 


### PR DESCRIPTION
## Description
If the provisioner fails to create a runner, an alert will be sent to #health-monitors.
The following errors are tracked:
1. Provisioner can't list existing runners in GitHub, which will prevent creation of new ones.
2. An error happened while provisioning a new runner in AWS.

## Blast Radius
None

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [x] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [ ] My changes do not have any impact on monitoring.

I'll test that the alert triggers after it's deployed.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Cause an error by blocking the `d6eautomaton` user from being able to query existing runners, and make sure that alert is sent to slack.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
- [Add an alert for when the GitHub runner provisioner can’t create runners](https://www.notion.so/datawire/Add-an-alert-for-when-the-GitHub-runner-provisioner-can-t-create-runners-90a2312f5aee4a52a38554bb25d7e416).

## Deployment plan
Merge PR