### PR TITLE
Reduce log level for non-errors

### DIFF
--- a/github-runner-provisioner/main.go
+++ b/github-runner-provisioner/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"net/http"
+	"os"
+
 	"github.com/datawire/infra-actions/github-runner-provisioner/internal/aws"
 	"github.com/datawire/infra-actions/github-runner-provisioner/internal/monitoring"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"os"
 )
 
 func init() {

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -67,7 +67,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusBadRequest)
 		log.WithFields(setupLogFields(r, http.StatusBadRequest, requestTime)).Warningf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"warning": monitoring.ErrorInvalidPayload.String(), "runner_label": "", "repo": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String(), "runner_label": "", "repo": ""}).Inc()
 		return
 	}
 
@@ -85,7 +85,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
 		log.WithFields(setupLogFields(r, http.StatusOK, requestTime)).Infof("Ignoring GitHub event with action %s for repository %s", *workflowJobEvent.Action, *workflowJobEvent.Repo.Name)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"info": monitoring.ErrorUnknownAction.String(),
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(),
 			"runner_label": "", "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
@@ -106,7 +106,7 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, message, http.StatusOK)
 		log.WithFields(setupLogFields(r, http.StatusOK, requestTime)).Infof(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"info": monitoring.ErrorUnknownRunnerLabel.String(),
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(),
 			"runner_label": jobLabel, "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}

--- a/github-runner-provisioner/requesthandler.go
+++ b/github-runner-provisioner/requesthandler.go
@@ -65,9 +65,9 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		message := fmt.Sprintf("Request is not a workflow job event: %v", err)
 		http.Error(w, message, http.StatusBadRequest)
-		log.WithFields(setupLogFields(r, http.StatusBadRequest, requestTime)).Errorf(message)
+		log.WithFields(setupLogFields(r, http.StatusBadRequest, requestTime)).Warningf(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorInvalidPayload.String(), "runner_label": "", "repo": ""}).Inc()
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"warning": monitoring.ErrorInvalidPayload.String(), "runner_label": "", "repo": ""}).Inc()
 		return
 	}
 
@@ -83,9 +83,9 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 
 	if *workflowJobEvent.Action != "queued" {
 		http.Error(w, http.StatusText(http.StatusOK), http.StatusOK)
-		log.WithFields(setupLogFields(r, http.StatusOK, requestTime)).Warningf("Ignoring GitHub event with action %s for repository %s", *workflowJobEvent.Action, *workflowJobEvent.Repo.Name)
+		log.WithFields(setupLogFields(r, http.StatusOK, requestTime)).Infof("Ignoring GitHub event with action %s for repository %s", *workflowJobEvent.Action, *workflowJobEvent.Repo.Name)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownAction.String(),
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"info": monitoring.ErrorUnknownAction.String(),
 			"runner_label": "", "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}
@@ -104,9 +104,9 @@ func handleProvisioningRequest(w http.ResponseWriter, r *http.Request) {
 	if runnerFunction == nil {
 		message := fmt.Sprintf("Workflow job didn't request a supported runner. Requested %v", workflowJobEvent.WorkflowJob.Labels)
 		http.Error(w, message, http.StatusOK)
-		log.WithFields(setupLogFields(r, http.StatusOK, requestTime)).Errorf(message)
+		log.WithFields(setupLogFields(r, http.StatusOK, requestTime)).Infof(message)
 
-		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"error": monitoring.ErrorUnknownRunnerLabel.String(),
+		monitoring.RunnerProvisioningErrors.With(prometheus.Labels{"info": monitoring.ErrorUnknownRunnerLabel.String(),
 			"runner_label": jobLabel, "repo": *workflowJobEvent.Repo.Name}).Inc()
 		return
 	}


### PR DESCRIPTION
## Description
GRP is logging non-error results as errors, making logs less useful and potentially clouding future monitoring efforts. 

## Blast Radius
Minimal, no direct impacts at the moment. 

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [X] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [X] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [ ] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [X] My changes do not have any impact on Rosie's checklists.

## Testing
- [X] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Minimal testing required, compiles and logs as expected. 

## Security
- [X] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
N/A

## Deployment plan
Fire and forget 👍 