### PR TITLE
buffed ubuntu-arm64 instance size from medium to xlarge

### DIFF
--- a/github-runner-provisioner/internal/aws/aws_runners/ubuntuarm64.go
+++ b/github-runner-provisioner/internal/aws/aws_runners/ubuntuarm64.go
@@ -46,7 +46,7 @@ var ubuntuArm64RunnerConfig = runnerConfig{
 	placement:        types.Placement{},
 	instanceCount:    1,
 	shutdownBehavior: "terminate",
-	instanceType:     "t4g.medium",
+	instanceType:     "t4g.xlarge",
 	keyName:          "m1_mac_runners",
 	// keeping default volume size hardcoded to 50gb
 	blockDeviceMappings: &[]types.BlockDeviceMapping{


### PR DESCRIPTION
## Description

Increasing `ubuntu-arm64` AWS instance size from `t4g.medium` to `t4g.xlarge`.

## Blast Radius

Increased AWS costs for billing.

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [X] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [ ] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [ ] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [ ] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [x] My changes do not require testing.

### Testing Strategy
A few sentences describing your tests. For example:
1. What changes are not tested and why.
2. What changes are riskier, and how are they tested.

## Security
- [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
List any issues or corrective actions related to this PR.

## Deployment plan
Describe what steps are necessary after merging PR, like:
- Manual tests.
- Dashboards or other monitoring tools that will be used to identify possible issues.
