### PR TITLE
Bump GitHub Runner version to 308

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,9 +5,9 @@ workflows:
     scripts:
       - echo "Starting runner for $GITHUB_REPO_OWNER/$GITHUB_REPO_NAME with label $GITHUB_RUNNER_LABELS"
       - |
-        curl -o actions-runner-osx-arm64-2.305.0.tar.gz \
-        -L https://github.com/actions/runner/releases/download/v2.305.0/actions-runner-osx-arm64-2.305.0.tar.gz
-      - tar xzf ./actions-runner-osx-arm64-2.305.0.tar.gz
+        curl -o actions-runner-osx-arm64.tar.gz \
+        -L https://github.com/actions/runner/releases/download/v2.308.0/actions-runner-osx-x64-2.308.0.tar.gz
+      - tar xzf ./actions-runner-osx-arm64.tar.gz
       - |
         ./config.sh \
         --name CodeMagic-Mac-M1-$BUILD_NUMBER \

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -14,5 +14,5 @@ workflows:
         --url https://github.com/$GITHUB_REPO_OWNER/$GITHUB_REPO_NAME \
         --token $GITHUB_RUNNER_TOKEN \
         --labels $GITHUB_RUNNER_LABELS \
-        --unattended --ephemeral --disableupdate
+        --unattended --ephemeral
       - ./run.sh

--- a/github-runner-provisioner/internal/aws/aws_runners/macm1.go
+++ b/github-runner-provisioner/internal/aws/aws_runners/macm1.go
@@ -8,7 +8,7 @@ import (
 )
 
 const AmiMacOs12_6Arm64 = "ami-01b8fcd5770ceb9c1"
-const macM1RunnerInstaller = "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-osx-arm64-2.298.2.tar.gz"
+const macM1RunnerInstaller = "https://github.com/actions/runner/releases/download/v2.308.0/actions-runner-osx-x64-2.308.0.tar.gz"
 const macM1UserDataTemplate = `#!/bin/bash
 set -x
 

--- a/github-runner-provisioner/internal/aws/aws_runners/ubuntuarm64.go
+++ b/github-runner-provisioner/internal/aws/aws_runners/ubuntuarm64.go
@@ -9,7 +9,7 @@ import (
 )
 
 const AmiUbuntuArm64 = "ami-0f69dd1d0d03ad669"
-const ubuntuArm64RunnerInstaller = "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz"
+const ubuntuArm64RunnerInstaller = "https://github.com/actions/runner/releases/download/v2.308.0/actions-runner-linux-arm64-2.308.0.tar.gz"
 const ubuntuArm64UserDataTemplate = `#!/bin/bash
 set -ex
 


### PR DESCRIPTION
## Description
The GitHub Runner version is deprecated, causing runners to fail to pick up new jobs and just circle on an error. By bumping the version runners will be able to pick up jobs again.

## Blast Radius
Things are already broken, this can't really make them worse. 

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [X] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [X] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [X] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [X] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [ ] My changes do not require testing.

### Testing Strategy
Allocated an M1 runner to the Infra Actions repo and ran a simple "hello world" job. 

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions
List any issues or corrective actions related to this PR.

## Deployment plan
Merge and restart the waiting jobs to allocate new runners. 
