### PR TITLE
Updating base Kubernetes versions to 1.27

### DIFF
--- a/.github/actions/provision-cluster/README.md
+++ b/.github/actions/provision-cluster/README.md
@@ -3,26 +3,26 @@
 Use the `provision-cluster` action as described below:
 
 ```yaml
-      - uses: ./provision-cluster
-        with:
-          # Tells the action what kind of cluster to create. One of: Kubeception, GKE, EKS, AKS, OpenShift
-          distribution: ...
-          # Tells the action what version of cluster to create.
-          version: 1.23
-          # Tells provision-cluster where to write the kubeconfig file.
-          kubeconfig: path/to/kubeconfig.yaml
+- uses: ./provision-cluster
+  with:
+    # Tells the action what kind of cluster to create. One of: Kubeception, GKE, EKS, AKS, OpenShift
+    distribution: ...
+    # Tells the action what version of cluster to create.
+    version: 1.27
+    # Tells provision-cluster where to write the kubeconfig file.
+    kubeconfig: path/to/kubeconfig.yaml
 
-          ## For kubeception klusters
+    ## For kubeception klusters
 
-          # A kubeception secret token
-          kubeceptionToken: ...
+    # A kubeception secret token
+    kubeceptionToken: ...
 
-          ## For GKE clusters:
+    ## For GKE clusters:
 
-          # A json encoded string containing GKE credentials:
-          gkeCredentials: ...
-          # A json encoded string containing additional GKE cluster configuration. See GKE Cluster Config Options section for details.
-          gkeConfig: ...
+    # A json encoded string containing GKE credentials:
+    gkeCredentials: ...
+    # A json encoded string containing additional GKE cluster configuration. See GKE Cluster Config Options section for details.
+    gkeConfig: ...
 ```
 
 ## GKE Cluster Config Options
@@ -174,17 +174,12 @@ The values included below are the defaults.
   "autopilot": null,
   "loggingConfig": {
     "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS",
-        "WORKLOADS"
-      ]
+      "enableComponents": ["SYSTEM_COMPONENTS", "WORKLOADS"]
     }
   },
   "monitoringConfig": {
     "componentConfig": {
-      "enableComponents": [
-        "SYSTEM_COMPONENTS"
-      ]
+      "enableComponents": ["SYSTEM_COMPONENTS"]
     },
     "managedPrometheusConfig": null
   },

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -1,18 +1,5 @@
-# This github workflow illustrates how to use the github actions matrix strategy to run the same
-# test code in many different environments using many different versions of various dependencies.
-#
-# The test matrix as a whole consits of two parts/sub-matrices (1) the various client environments,
-# and (2) the various cluster environments.
-#
-# The client environment is provided by the github runner itself (see the "runs-on" field for more
-# details). The cluster environment is created by the (currently stubbed) provision-cluster github
-# action.
-#
-# See the "matrix" field below for more info about how the test matrix is described.
-
 name: "Telepresence Test Matrix"
 on:
-  # Using pull_request for ease of iteration, but "workflow_dispatch" will let us manually trigger with parameters.
   pull_request:
     paths:
       - .github/workflows/matrix.yaml
@@ -27,10 +14,6 @@ on:
 jobs:
   telepresence_matrix:
     strategy:
-      # Each value in the test matrix map is a list of options. This strategy spawns one job for
-      # every element in the cross product of all these lists. The values for that particular cell
-      # of the test matrix are accessed in the job definition via the matrix context below, e.g.:
-      #   ${{ matrix.client_os }}
       matrix:
 
         client_os: [ubuntu]
@@ -40,45 +23,17 @@ jobs:
 
         clusters:
          - distribution: GKE
-           version: "1.23"
+           version: "1.27"
 
          - distribution: Kubeception
-           version: "1.22"
+           version: "1.27"
 
          - distribution: GKE
-           version: "1.23"
+           version: "1.27"
            config: '{ "initialNodeCount" : 2 }'
 
         cluster_telepresence_version:  ["none"]
 
-## Below is a larger matrix intended to illustrate how more permutations would be expressed. The
-## above constrained set is used for dev purposes:
-#
-#        client_os: [ubuntu-22.04, ubuntu-20.04]
-#        client_arch: [arm, x86]
-#
-#        client_telepresence_version: ["2.7", "2.6", "2.5"]
-#
-#        clusters:
-#         - distribution: GKE
-#           version: "1.23"
-#         - distribution: GKE
-#           version: "1.22"
-#         - distribution: GKE
-#           version: "1.21"
-#
-#         - distribution: AKS
-#           version: "1.22"
-#         - distribution: AKS
-#           version: "1.21"
-#         - distribution: AKS
-#           version: "1.20"
-#
-#        cluster_telepresence_version:  ["none", "2.7", "2.6", "2.5"]
-
-    # The runs-on field defines the client portion of the environment. This currently includes all
-    # github hosted runner options and will be augmented by our self hosted macos runners to fill in
-    # that portion of the matrix.
     runs-on: ${{ matrix.client_os }}-${{ matrix.client_arch }}
     steps:
       - uses: actions/checkout@v3
@@ -87,8 +42,6 @@ jobs:
         with:
           # These tests require Kubectl 1.25 or lower since 1.26+ does noe support the GCP auth plugin
           version: 'v1.25.3'
-      # The provision-cluster action will automatically register a cleanup hook to remove the
-      # cluster it provisions when the job is done.
       - uses: ./provision-cluster
         with:
           distribution: ${{ matrix.clusters.distribution }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         clusters:
          - distribution: GKE
-           version: "1.23"
+           version: "1.27"
            useAuthProvider: "true"
 
          - distribution: GKE
-           version: "1.23"
+           version: "1.27"
            useAuthProvider: "false"
 
          - distribution: Kubeception
-           version: "1.22"
+           version: "1.27"
     runs-on: ubuntu-latest
     steps:
       - name: Kubectl tool installer

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -22,15 +22,15 @@ jobs:
       matrix:
         clusters:
           - distribution: GKE
-            version: "1.23"
+            version: "1.27"
             useAuthProvider: "false"
           - distribution: GKE
-            version: "1.23"
+            version: "1.27"
             useAuthProvider: "true"
           - distribution: AKS
-            version: "1.22"
+            version: "1.27"
           - distribution: Kubeception
-            version: "1.23"
+            version: "1.27"
     steps:
       # The provision-cluster action will automatically register a cleanup hook to remove the
       # cluster it provisions when the job is done.


### PR DESCRIPTION
## Description

GKE 1.23 is no longer supported. Updated the base Kubernetes version to 1.27. Ideally this would be the latest 1.29 version, but Kubeception does not yet support this (although that will be changing this week), so we'll start with the minimum 1.27 version consistently first.
