### PR TITLE
Add default VSCode settings/extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /github-runner-provisioner/github-runner-provisioner
+
+.idea
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "files.insertFinalNewline": true,
+    "[go]": {
+        "editor.formatOnSave": true
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.indentSize": 2,
+        "editor.insertSpaces": true
+    }
+}


### PR DESCRIPTION
## Description

It's always debatable, but I prefer to keep minimal, relevant VSCode settings/extensions in the repo directly.
This is just to keep consistency on some basic best practices.

In this case, it's basically a bomb waiting to go off, because none of the Javascript files are formatted per standards.

I'll probably just format them all (automatically) in the future, but I've been avoiding it so far.