### PR TITLE
Update examples to use preferred format

### DIFF
--- a/.github/actions/provision-cluster/README.md
+++ b/.github/actions/provision-cluster/README.md
@@ -3,7 +3,7 @@
 ## Example Usage
 
 ```yaml
-- uses: ./provision-cluster
+- uses: datawire/infra-actions/provision-cluster@v0.2.5
   with:
     distribution: Kubeception
     version: 1.27
@@ -13,7 +13,7 @@
 ```
 
 ```yaml
-- uses: ./provision-cluster
+- uses: datawire/infra-actions/provision-cluster@v0.2.5
   with:
     distribution: GKE
     version: 1.27


### PR DESCRIPTION
## Description

Updates the documentation example `uses:` to refer to the traditional GitHub Actions format. The use of internal pathing (i.e. `./provision-cluster`) should not be a recommended approach, as this is not considered standard use. It's fine to use this internally for testing latest changes without a release/tag, but it should not be used or recommended under any other circumstances.
