### PR TITLE
Cluster clients are created as needed

### DIFF
--- a/.github/actions/provision-cluster/lib/registry.js
+++ b/.github/actions/provision-cluster/lib/registry.js
@@ -1,25 +1,30 @@
-'use strict';
+"use strict";
 
-const gke = require('./gke.js')
-const kubeception = require('./kubeception.js')
+const gke = require("./gke.js");
+const kubeception = require("./kubeception.js");
 
-const CLUSTER_NAME = 'CLUSTER_NAME'
-const clusterZone = 'us-central1-b'
+const CLUSTER_NAME = "CLUSTER_NAME";
+const clusterZone = "us-central1-b";
 
-const distributions = {
-  "gke": new gke.Client(clusterZone),
-  "kubeception": new kubeception.Client(kubeception.getHttpClient())
-}
+const DistributionType = {
+  GKE: "gke",
+  KUBECEPTION: "kubeception",
+};
 
 function getProvider(distribution) {
-  let result = distributions[distribution.toLowerCase()]
-  if (typeof result === typeof undefined) {
-    throw new Error(`unknown distribution: ${distribution}`)
+  const lowerCaseDistribution = distribution.toLowerCase();
+
+  switch (lowerCaseDistribution) {
+    case DistributionType.GKE:
+      return new gke.Client(clusterZone);
+    case DistributionType.KUBECEPTION:
+      return new kubeception.Client(kubeception.getHttpClient());
+    default:
+      throw new Error(`unknown distribution: ${distribution}`);
   }
-  return result
 }
 
 module.exports = {
   getProvider,
-  CLUSTER_NAME
-}
+  CLUSTER_NAME,
+};

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -42,6 +42,9 @@ jobs:
         cluster_telepresence_version:  ["none"]
 
     runs-on: ${{ matrix.client_os }}-${{ matrix.client_arch }}
+    env:
+      KUBECEPTION_TOKEN: ${{ secrets.KUBECEPTION_TOKEN }}
+      GKE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
     steps:
       - uses: actions/checkout@v4
       - name: Kubectl tool installer
@@ -54,8 +57,8 @@ jobs:
           distribution: ${{ matrix.clusters.distribution }}
           version: ${{ matrix.clusters.version }}
           kubeconfig: kubeconfig.yaml
-          kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
-          gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          kubeceptionToken: ${{ matrix.clusters.distribution == 'Kubeception' && env.KUBECEPTION_TOKEN }}
+          gkeCredentials: ${{ matrix.clusters.distribution == 'GKE' && env.GKE_CREDENTIALS }}
           gkeConfig: ${{ matrix.clusters.config }}
 
       - run: |


### PR DESCRIPTION
## Description

Create the cluster client when necessary, rather than instantiate global distribution clients.
Minimally reworks the `matrix` tests to ensure both sets of credentials are not passed for all distributions.

Closes #66