### PR TITLE
Update smoke test credential usage

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -24,6 +24,9 @@ jobs:
          - distribution: Kubeception
            version: "1.27"
     runs-on: ubuntu-latest
+    env:
+      KUBECEPTION_TOKEN: ${{ secrets.KUBECEPTION_TOKEN }}
+      GKE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
     steps:
       - name: Kubectl tool installer
         uses: Azure/setup-kubectl@v3
@@ -35,8 +38,8 @@ jobs:
           distribution: ${{ matrix.clusters.distribution }}
           version: ${{ matrix.clusters.version }}
           kubeconfig: ${{ runner.temp}}/kubeconfig.yaml
-          kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
-          gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          kubeceptionToken: ${{ matrix.clusters.distribution == 'Kubeception' && env.KUBECEPTION_TOKEN }}
+          gkeCredentials: ${{ matrix.clusters.distribution == 'GKE' && env.GKE_CREDENTIALS }}
           useAuthProvider: ${{ matrix.clusters.useAuthProvider }}
       - name: "Get kubeconfig and cluster information"
         run: |


### PR DESCRIPTION
## Description

Mimics the change made to `matrix.yaml` recently. This ensures that both Kubeception credentials and GKE credentials are not simultaneously required for every cluster. This was a previous defect (that has now been fixed in #85) that was never caught due to the way these tests are structured.

It's a slightly cheesy way of accomplishing this, but it's better than a more substantial rework of the testing.

## Blast Radius

None.

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [x] My changes do not require testing.

### Testing Strategy

Existing tests.

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions

N/A

## Deployment plan

Ensure test runs successfully after merge.