### PR TITLE
Update to use new kluster kubeconfig endpoint

### DIFF
--- a/.github/actions/provision-cluster/lib/kubeception.test.js
+++ b/.github/actions/provision-cluster/lib/kubeception.test.js
@@ -23,6 +23,13 @@ test("kubeception profile", async () => {
         inputs.kubeceptionProfile
       );
 
+      return {
+        message: {
+          statusCode: 200,
+        },
+      };
+    }
+    async get() {
       let status = 200;
       if (count < 2) {
         status = 425;


### PR DESCRIPTION
## Description

Migrates to the new kluster kubeconfig endpoint. Put/Get kluster commands will no longer have the option to return the kubeconfig directly in future iterations. Applying minimal refactoring for now, leaving most of the existing logic in place.