### PR TITLE
Run Matrix CI on push to main

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - integration/**
+      - main
     paths-ignore:
       - '**/*.md'
   pull_request:


### PR DESCRIPTION
## Description

Updates `matix.yaml` to always run when pushing to the `main` branch.
