### PR TITLE
Set keepAlive to false

### DIFF
--- a/.github/actions/provision-cluster/lib/kubeception.js
+++ b/.github/actions/provision-cluster/lib/kubeception.js
@@ -169,7 +169,10 @@ function getHttpClient() {
   const credentialHandler = new httpClientLib.BearerCredentialHandler(
     kubeceptionToken
   );
-  return new httpClient.HttpClient(userAgent, [credentialHandler]);
+
+  return new httpClient.HttpClient(userAgent, [credentialHandler], {
+    keepAlive: false,
+  });
 }
 
 module.exports = { Client, getHttpClient };

--- a/.github/actions/provision-cluster/lib/slack.js
+++ b/.github/actions/provision-cluster/lib/slack.js
@@ -13,7 +13,9 @@ async function notify(message) {
   const runbook = core.getInput("slackRunbook");
   const username = core.getInput("slackUsername");
 
-  const client = new http.HttpClient("datawire/provision-cluster");
+  const client = new http.HttpClient("datawire/provision-cluster", [], {
+    keepAlive: false,
+  });
 
   const body = {
     channel: channel,


### PR DESCRIPTION
## Description

The use of Node was upgraded from 16 to 20, per the rapidly approaching [deprecation of Node 16 in GitHub Actions](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20).

Noting that GitHub Actions does not support Node 18.

The use of Node 20 (by virtue of [Node 19](https://nodejs.org/en/blog/release/v19.0.0)) has changed `keepAlive` to be true by default.

> Starting with this release, Node.js sets keepAlive to true by default. This means that any outgoing HTTP(s) connection will automatically use HTTP 1.1 Keep-Alive.

This has had an impact on a great number of GitHub Actions. Reference [setup-ruby](https://github.com/ruby/setup-ruby/issues/543#issuecomment-1793608370) for one such issue.

Additionally, the `@actions/http-client` (which we are using) had to be [updated](https://github.com/actions/toolkit/pull/1572) to support the changes. I've updated all of our dependencies in #98, including `@actions/http-client` to pick up the necessary changes.

This fix includes the final necessary step to avoid the unnecessary delays.
