### PR TITLE
Upgrade provision-cluster to v0.3.1

### DIFF
--- a/.github/actions/provision-cluster/README.md
+++ b/.github/actions/provision-cluster/README.md
@@ -3,7 +3,7 @@
 ## Example Usage
 
 ```yaml
-- uses: datawire/infra-actions/provision-cluster@v0.3.0
+- uses: datawire/infra-actions/provision-cluster@v0.3.1
   with:
     distribution: Kubeception
     version: 1.27
@@ -13,7 +13,7 @@
 ```
 
 ```yaml
-- uses: datawire/infra-actions/provision-cluster@v0.3.0
+- uses: datawire/infra-actions/provision-cluster@v0.3.1
   with:
     distribution: GKE
     version: 1.27

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Kubectl tool installer
         uses: Azure/setup-kubectl@v3
       - id: provision
-        uses: datawire/infra-actions/provision-cluster@v0.3.0
+        uses: datawire/infra-actions/provision-cluster@v0.3.1
         with:
           distribution: GKE
           version: ${{ matrix.clusters.version }}
@@ -48,7 +48,7 @@ jobs:
       - name: Kubectl tool installer
         uses: Azure/setup-kubectl@v3
       - id: provision
-        uses: datawire/infra-actions/provision-cluster@v0.3.0
+        uses: datawire/infra-actions/provision-cluster@v0.3.1
         with:
           distribution: Kubeception
           version: ${{ matrix.clusters.version }}

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       # The provision-cluster action will automatically register a cleanup hook to remove the
       # cluster it provisions when the job is done.
-      - uses: datawire/infra-actions/provision-cluster@v0.3.0
+      - uses: datawire/infra-actions/provision-cluster@v0.3.1
         with:
           distribution: GKE
           version: ${{ matrix.clusters.version }}
@@ -44,7 +44,7 @@ jobs:
     steps:
       # The provision-cluster action will automatically register a cleanup hook to remove the
       # cluster it provisions when the job is done.
-      - uses: datawire/infra-actions/provision-cluster@v0.3.0
+      - uses: datawire/infra-actions/provision-cluster@v0.3.1
         with:
           distribution: Kubeception
           version: ${{ matrix.clusters.version }}


### PR DESCRIPTION
## Description

Updates the smoke test and documentation to reference the latest version `datawire/infra-actions/provision-cluster@v0.3.1`.
