### PR TITLE
Update from Kubernetes 1.27 to 1.29

### DIFF
--- a/.github/actions/provision-cluster/README.md
+++ b/.github/actions/provision-cluster/README.md
@@ -6,7 +6,7 @@
 - uses: datawire/infra-actions/provision-cluster@v0.3.1
   with:
     distribution: Kubeception
-    version: 1.27
+    version: 1.29
     kubeconfig: kubeconfig.yaml
 
     kubeceptionToken: ${{ secrets.KUBECEPTION_TOKEN }}
@@ -16,7 +16,7 @@
 - uses: datawire/infra-actions/provision-cluster@v0.3.1
   with:
     distribution: GKE
-    version: 1.27
+    version: 1.29
     kubeconfig: kubeconfig.yaml
 
     gkeCredentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}

--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -26,11 +26,11 @@ jobs:
         client_os: [ubuntu]
         client_arch: [latest]
         clusters:
-        - version: "1.27"
+        - version: "1.29"
           useAuthProvider: "true"
-        - version: "1.27"
+        - version: "1.29"
           useAuthProvider: "false"
-        - version: "1.27"
+        - version: "1.29"
           config: '{ "initialNodeCount" : 2 }'
     runs-on: ${{ matrix.client_os }}-${{ matrix.client_arch }}
     env:
@@ -67,7 +67,7 @@ jobs:
         client_os: [ubuntu]
         client_arch: [latest]
         clusters:
-          - version: "1.27"
+          - version: "1.29"
     runs-on: ${{ matrix.client_os }}-${{ matrix.client_arch }}
     env:
       KUBECEPTION_TOKEN: ${{ secrets.KUBECEPTION_TOKEN }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         clusters:
-         - version: "1.27"
+         - version: "1.29"
     runs-on: ubuntu-latest
     env:
       GKE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         clusters:
-         - version: "1.27"
+         - version: "1.29"
     runs-on: ubuntu-latest
     env:
       KUBECEPTION_TOKEN: ${{ secrets.KUBECEPTION_TOKEN }}

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         clusters:
-          - version: "1.26"
-          - version: "1.27"
           - version: "1.28"
+          - version: "1.29"
+          - version: "1.30"
     steps:
       # The provision-cluster action will automatically register a cleanup hook to remove the
       # cluster it provisions when the job is done.
@@ -38,9 +38,9 @@ jobs:
     strategy:
       matrix:
         clusters:
-          - version: "1.26"
-          - version: "1.27"
           - version: "1.28"
+          - version: "1.29"
+          - version: "1.30"
     steps:
       # The provision-cluster action will automatically register a cleanup hook to remove the
       # cluster it provisions when the job is done.


### PR DESCRIPTION
## Description

Update our baseline Kubernetes version to v1.29. GKE no longer supports v1.27, so these tests/docs are officially outdated and unsupported. We don't support v1.30 and v1.31 in Kubeception (yet, and I'll probably deal with that tomorrow), and I'll update this handling accordingly after we do.

## Blast Radius

N/A

## Dependencies and documentation
### Documentation
- [ ] I have updated user facing documentation.
- [ ] I have updated all Runbooks affected by this change.
- [ ]  I updated `DEVELOPING.md` with any dev tricks I used to work on this code efficiently.
- [x] My changes do not have any impact on documentation.

### Monitoring
- [ ] I have verified that any changes to alerts work as expected.
- [ ] My changes affect monitoring rules and/or dashboards, and I made sure they didn't break.
- [x] My changes do not have any impact on monitoring.

### External dependencies
- [ ] I have validated that dependencies impacted by this change work as expected.
- [x] My changes do not impact external dependencies.

### Rosie the Robot checklists
- [ ] My changes affect one or more Rosie checklists.
- [x] My changes do not have any impact on Rosie's checklists.

## Testing
- [ ] I have validated that my changes work as expected.
- [x] My changes do not require testing.

### Testing Strategy

N/A

## Security
- [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.

## Related Issues or corrective actions

N/A
## Deployment plan
Describe what steps are necessary after merging PR, like:
- Manual tests.
- Dashboards or other monitoring tools that will be used to identify possible issues.
